### PR TITLE
fix: use PAT in squad-auto-label to trigger triage workflow

### DIFF
--- a/.github/workflows/squad-auto-label.yml
+++ b/.github/workflows/squad-auto-label.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Add squad label to new issue
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
           script: |
             const issue = context.payload.issue;
             


### PR DESCRIPTION
Uses COPILOT_ASSIGN_TOKEN instead of GITHUB_TOKEN in squad-auto-label.yml so the label event triggers the downstream squad-triage.yml workflow. Without this, GitHub suppresses workflow-to-workflow triggers from the default token.