### PR TITLE
fix: default to @copilot when no squad member keyword matches

### DIFF
--- a/.github/workflows/squad-auto-label.yml
+++ b/.github/workflows/squad-auto-label.yml
@@ -142,9 +142,16 @@ jobs:
               }
             }
 
+            // Default: route to @copilot unless explicitly not suitable
             if (!assignedMember) {
-              assignedMember = lead;
-              triageReason = 'No specific domain match — assigned to Lead for further analysis';
+              if (hasCopilot && copilotTier !== 'not-suitable') {
+                copilotTier = 'good-fit';
+                assignedMember = { name: '@copilot', role: 'Coding Agent' };
+                triageReason = '🟢 No specific squad member match — routing to @copilot for autonomous work';
+              } else {
+                assignedMember = lead;
+                triageReason = 'Not suitable for @copilot — assigned to Lead for further analysis';
+              }
             }
 
             // Step 4: Apply labels


### PR DESCRIPTION
Changes the fallback in squad-auto-label.yml: when no squad member keyword matches and the issue is not explicitly unsuitable, route to @copilot instead of Lead. This means @copilot picks up most issues autonomously.