### PR TITLE
feat: add floating TOC + reading progress bar for posts

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -52,6 +52,7 @@ common-ext-js:
   <script src="{{ '/assets/js/scroll-to-top.js' | relative_url }}"></script>
   <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
   <script src="{{ '/assets/js/command-palette.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/post-toc.js' | relative_url }}"></script>
   <script src="{{ '/assets/js/google-analytics.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -2175,3 +2175,273 @@ body.cmd-palette-open {
     max-height: 55vh;
   }
 }
+
+/* ===== READING PROGRESS BAR ===== */
+.reading-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  z-index: 10000;
+  background: transparent;
+  pointer-events: none;
+}
+
+.reading-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent-col), var(--hover-col));
+  border-radius: 0 2px 2px 0;
+  transition: width 80ms linear;
+  will-change: width;
+}
+
+/* ===== FLOATING TABLE OF CONTENTS ===== */
+.post-toc {
+  position: fixed;
+  top: 90px;
+  right: -300px;
+  width: 260px;
+  max-height: calc(100vh - 120px);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  opacity: 0;
+  transition: right 0.35s cubic-bezier(0.4, 0.2, 0.2, 1),
+              opacity 0.35s cubic-bezier(0.4, 0.2, 0.2, 1);
+  overflow: hidden;
+}
+
+.post-toc--visible {
+  right: 24px;
+  opacity: 1;
+}
+
+.post-toc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--card-border);
+  flex-shrink: 0;
+}
+
+.post-toc-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mid-col);
+}
+
+.post-toc-collapse {
+  display: none; /* shown on smaller screens */
+  background: none;
+  border: none;
+  color: var(--mid-col);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 12px;
+  transition: transform 0.2s ease;
+}
+.post-toc--collapsed .post-toc-collapse {
+  transform: rotate(180deg);
+}
+
+/* Nav list */
+.post-toc-nav {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  flex: 1;
+  padding: 8px 0;
+}
+.post-toc--collapsed .post-toc-nav {
+  display: none;
+}
+
+.post-toc-nav::-webkit-scrollbar {
+  width: 4px;
+}
+.post-toc-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+.post-toc-nav::-webkit-scrollbar-thumb {
+  background: var(--card-border);
+  border-radius: 2px;
+}
+
+.post-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.post-toc-item {
+  position: relative;
+}
+
+.post-toc-link {
+  display: block;
+  padding: 6px 16px 6px 16px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--mid-col);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.post-toc-link:hover {
+  color: var(--text-col);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.post-toc-link.active {
+  color: var(--accent-col);
+  border-left-color: var(--accent-col);
+  background: rgba(249, 115, 22, 0.06);
+  font-weight: 500;
+}
+
+/* Nested h3 items */
+.post-toc-item--nested .post-toc-link {
+  padding-left: 28px;
+  font-size: 12px;
+}
+
+/* Mobile toggle pill */
+.post-toc-toggle {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  color: var(--accent-col);
+  font-size: 16px;
+  cursor: pointer;
+  z-index: 101;
+  display: none; /* shown on smaller screens */
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.25s ease, transform 0.25s ease, background 0.15s ease;
+}
+.post-toc-toggle--visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.post-toc-toggle:hover {
+  background: rgba(249, 115, 22, 0.1);
+}
+
+/* ===== RESPONSIVE: TABLE OF CONTENTS ===== */
+
+/* Large desktops: TOC alongside content */
+@media (min-width: 1200px) {
+  .post-toc--visible {
+    right: max(24px, calc((100vw - 1140px) / 2 - 280px));
+  }
+}
+
+/* Medium screens: narrower TOC, tighter position */
+@media (max-width: 1400px) {
+  .post-toc {
+    width: 220px;
+  }
+}
+
+/* Backdrop scrim for mobile TOC */
+.post-toc-backdrop {
+  display: none;
+}
+
+/* Tablets and below: bottom sheet TOC with backdrop */
+@media (max-width: 1199px) {
+  .post-toc-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    z-index: 999;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+  .post-toc-backdrop--visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .post-toc {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    max-height: 55vh;
+    border-radius: 16px 16px 0 0;
+    transform: translateY(100%);
+    opacity: 1;
+    z-index: 1000;
+    transition: transform 0.3s cubic-bezier(0.4, 0.2, 0.2, 1);
+  }
+  .post-toc--visible {
+    /* Still offscreen until expanded */
+    right: 0;
+    opacity: 1;
+  }
+  .post-toc--visible.post-toc--expanded {
+    transform: translateY(0);
+  }
+  .post-toc-header {
+    padding: 16px 20px 12px;
+  }
+  /* Drag handle hint */
+  .post-toc-header::before {
+    content: '';
+    display: block;
+    width: 36px;
+    height: 4px;
+    background: var(--card-border);
+    border-radius: 2px;
+    margin: 0 auto 12px;
+  }
+  .post-toc-collapse {
+    display: inline-flex;
+  }
+  .post-toc-toggle {
+    display: flex;
+  }
+  .post-toc-link {
+    padding: 10px 20px 10px 20px;
+    font-size: 15px;
+    white-space: normal;
+  }
+  .post-toc-item--nested .post-toc-link {
+    padding-left: 32px;
+    font-size: 14px;
+  }
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .post-toc,
+  .post-toc-toggle,
+  .reading-progress-fill {
+    transition: none;
+  }
+}

--- a/assets/js/post-toc.js
+++ b/assets/js/post-toc.js
@@ -1,0 +1,249 @@
+/**
+ * Post Table of Contents + Reading Progress Bar
+ *
+ * Auto-generates a floating TOC from post headings (h2/h3) with:
+ * - Reading progress bar at the top of the page
+ * - Active section highlighting via Intersection Observer
+ * - Smooth-scroll on click
+ * - Collapsible on mobile (toggle button)
+ * - Hides automatically on posts with fewer than 3 headings
+ */
+(function () {
+  'use strict';
+
+  const POST_SELECTOR = '.blog-post';
+  const HEADING_SELECTOR = 'h2, h3';
+  const MIN_HEADINGS = 3;
+  const SCROLL_OFFSET = 80; // navbar height + breathing room
+
+  // --- Wait for DOM ---
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    const post = document.querySelector(POST_SELECTOR);
+    if (!post) return;
+
+    const headings = Array.from(post.querySelectorAll(HEADING_SELECTOR));
+    if (headings.length < MIN_HEADINGS) return;
+
+    // Ensure every heading has an id for anchor linking
+    headings.forEach(function (h, i) {
+      if (!h.id) {
+        h.id = 'heading-' + i + '-' + slugify(h.textContent);
+      }
+    });
+
+    createProgressBar();
+    createTOC(headings);
+    observeHeadings(headings);
+    trackProgress(post);
+  }
+
+  // --- Reading Progress Bar ---
+  function createProgressBar() {
+    var bar = document.createElement('div');
+    bar.className = 'reading-progress';
+    bar.setAttribute('role', 'progressbar');
+    bar.setAttribute('aria-label', 'Reading progress');
+    bar.setAttribute('aria-valuemin', '0');
+    bar.setAttribute('aria-valuemax', '100');
+    bar.setAttribute('aria-valuenow', '0');
+
+    var fill = document.createElement('div');
+    fill.className = 'reading-progress-fill';
+    bar.appendChild(fill);
+    document.body.appendChild(bar);
+  }
+
+  function trackProgress(post) {
+    var fill = document.querySelector('.reading-progress-fill');
+    var bar = document.querySelector('.reading-progress');
+    if (!fill || !bar) return;
+
+    var ticking = false;
+    window.addEventListener('scroll', function () {
+      if (!ticking) {
+        requestAnimationFrame(function () {
+          var rect = post.getBoundingClientRect();
+          var postTop = rect.top + window.scrollY;
+          var postHeight = rect.height;
+          var scrolled = window.scrollY - postTop + window.innerHeight * 0.3;
+          var pct = Math.max(0, Math.min(100, (scrolled / postHeight) * 100));
+          fill.style.width = pct + '%';
+          bar.setAttribute('aria-valuenow', Math.round(pct));
+          ticking = false;
+        });
+        ticking = true;
+      }
+    });
+  }
+
+  // --- Table of Contents ---
+  function createTOC(headings) {
+    // Container
+    var aside = document.createElement('aside');
+    aside.className = 'post-toc';
+    aside.setAttribute('aria-label', 'Table of contents');
+
+    // Header row
+    var header = document.createElement('div');
+    header.className = 'post-toc-header';
+
+    var title = document.createElement('span');
+    title.className = 'post-toc-title';
+    title.textContent = 'On this page';
+    header.appendChild(title);
+
+    // Collapse button (mobile)
+    var collapseBtn = document.createElement('button');
+    collapseBtn.className = 'post-toc-collapse';
+    collapseBtn.setAttribute('aria-label', 'Collapse table of contents');
+    collapseBtn.innerHTML = '<i class="fas fa-chevron-down"></i>';
+    header.appendChild(collapseBtn);
+
+    aside.appendChild(header);
+
+    // Nav list
+    var nav = document.createElement('nav');
+    nav.className = 'post-toc-nav';
+    var ol = document.createElement('ol');
+    ol.className = 'post-toc-list';
+
+    headings.forEach(function (h) {
+      var li = document.createElement('li');
+      li.className = 'post-toc-item';
+      if (h.tagName === 'H3') {
+        li.classList.add('post-toc-item--nested');
+      }
+
+      var a = document.createElement('a');
+      a.className = 'post-toc-link';
+      a.href = '#' + h.id;
+      a.textContent = h.textContent;
+      a.setAttribute('data-target', h.id);
+
+      a.addEventListener('click', function (e) {
+        e.preventDefault();
+        var target = document.getElementById(h.id);
+        if (target) {
+          var y = target.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET;
+          window.scrollTo({ top: y, behavior: 'smooth' });
+          history.replaceState(null, '', '#' + h.id);
+        }
+        // Auto-close on mobile after clicking
+        if (window.innerWidth < 1200) {
+          aside.classList.remove('post-toc--expanded');
+          var bd = document.querySelector('.post-toc-backdrop');
+          if (bd) bd.classList.remove('post-toc-backdrop--visible');
+        }
+      });
+
+      li.appendChild(a);
+      ol.appendChild(li);
+    });
+
+    nav.appendChild(ol);
+    aside.appendChild(nav);
+    document.body.appendChild(aside);
+
+    // Backdrop scrim (mobile)
+    var backdrop = document.createElement('div');
+    backdrop.className = 'post-toc-backdrop';
+    backdrop.addEventListener('click', function () {
+      aside.classList.remove('post-toc--expanded');
+      backdrop.classList.remove('post-toc-backdrop--visible');
+    });
+    document.body.appendChild(backdrop);
+
+    // Mobile toggle button (fixed pill)
+    var toggle = document.createElement('button');
+    toggle.className = 'post-toc-toggle';
+    toggle.setAttribute('aria-label', 'Toggle table of contents');
+    toggle.innerHTML = '<i class="fas fa-list-ul"></i>';
+    toggle.addEventListener('click', function () {
+      var opening = !aside.classList.contains('post-toc--expanded');
+      aside.classList.toggle('post-toc--expanded');
+      backdrop.classList.toggle('post-toc-backdrop--visible', opening);
+    });
+    document.body.appendChild(toggle);
+
+    // Collapse button toggles list visibility on small screens
+    collapseBtn.addEventListener('click', function () {
+      aside.classList.toggle('post-toc--collapsed');
+    });
+
+    // Show TOC after scrolling past the post header
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          aside.classList.remove('post-toc--visible');
+          toggle.classList.remove('post-toc-toggle--visible');
+        } else {
+          aside.classList.add('post-toc--visible');
+          toggle.classList.add('post-toc-toggle--visible');
+        }
+      });
+    }, { threshold: 0 });
+
+    var postHeader = document.querySelector('.header-section');
+    if (postHeader) {
+      observer.observe(postHeader);
+    } else {
+      // Fallback: show immediately
+      aside.classList.add('post-toc--visible');
+      toggle.classList.add('post-toc-toggle--visible');
+    }
+  }
+
+  // --- Intersection Observer for Active Section ---
+  function observeHeadings(headings) {
+    var links = document.querySelectorAll('.post-toc-link');
+    if (!links.length) return;
+
+    var observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            // Remove active from all
+            links.forEach(function (l) { l.classList.remove('active'); });
+            // Set current
+            var id = entry.target.id;
+            var activeLink = document.querySelector('.post-toc-link[data-target="' + id + '"]');
+            if (activeLink) {
+              activeLink.classList.add('active');
+              // Scroll the TOC nav to keep active item visible
+              scrollTocIntoView(activeLink);
+            }
+          }
+        });
+      },
+      {
+        rootMargin: '-' + SCROLL_OFFSET + 'px 0px -65% 0px',
+        threshold: 0
+      }
+    );
+
+    headings.forEach(function (h) { observer.observe(h); });
+  }
+
+  function scrollTocIntoView(link) {
+    var nav = document.querySelector('.post-toc-nav');
+    if (!nav) return;
+    var navRect = nav.getBoundingClientRect();
+    var linkRect = link.getBoundingClientRect();
+    if (linkRect.top < navRect.top || linkRect.bottom > navRect.bottom) {
+      link.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }
+
+  // --- Helpers ---
+  function slugify(text) {
+    return text
+      .toLowerCase()
+      .trim()
+      .replace(/[^\w\s-]/g, '')
+      .replace(/[\s_]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .substring(0, 60);
+  }
+})();

--- a/tests/command-palette.spec.ts
+++ b/tests/command-palette.spec.ts
@@ -87,10 +87,13 @@ test.describe('Command Palette', () => {
     await paletteInput(page).fill('DevOps');
     await expect(paletteResults(page).first()).toBeVisible({ timeout: 5000 });
 
+    // Wait for debounce (150ms) to fully settle before sending keys
+    await page.waitForTimeout(300);
+
     await page.keyboard.press('ArrowDown');
 
     const highlighted = palette(page).locator('[aria-selected="true"]');
-    await expect(highlighted).toHaveCount(1);
+    await expect(highlighted).toHaveCount(1, { timeout: 3000 });
   });
 
   test('Enter navigates to the selected post', async ({ page }) => {

--- a/tests/post-toc.spec.ts
+++ b/tests/post-toc.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+
+// Use a post known to have multiple h2 headings
+const POST_WITH_HEADINGS = '/blog/2026/building-an-ai-agent-squad-for-your-repo';
+
+test.describe('Post Table of Contents + Reading Progress', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(POST_WITH_HEADINGS);
+    // Wait for TOC script to initialize
+    await page.waitForSelector('.post-toc', { timeout: 10000 });
+  });
+
+  test('reading progress bar exists and starts at 0%', async ({ page }) => {
+    const bar = page.locator('.reading-progress');
+    await expect(bar).toBeAttached();
+    await expect(bar).toHaveAttribute('role', 'progressbar');
+
+    const fill = page.locator('.reading-progress-fill');
+    await expect(fill).toBeAttached();
+  });
+
+  test('reading progress bar fills on scroll', async ({ page }) => {
+    const fill = page.locator('.reading-progress-fill');
+
+    // Scroll to middle of post
+    await page.evaluate(() => {
+      const post = document.querySelector('.blog-post');
+      if (post) {
+        const midY = post.getBoundingClientRect().top + window.scrollY + post.getBoundingClientRect().height / 2;
+        window.scrollTo({ top: midY });
+      }
+    });
+    await page.waitForTimeout(200);
+
+    // Width should be > 0
+    const width = await fill.evaluate((el) => parseFloat(getComputedStyle(el).width));
+    expect(width).toBeGreaterThan(0);
+  });
+
+  test('TOC is generated with correct heading links', async ({ page }) => {
+    const tocLinks = page.locator('.post-toc-link');
+    const count = await tocLinks.count();
+
+    // The Squad post has 7 h2s — should have at least 3+
+    expect(count).toBeGreaterThanOrEqual(3);
+
+    // Each link should have text and an href starting with #
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      const link = tocLinks.nth(i);
+      await expect(link).toHaveAttribute('href', /^#/);
+      const text = await link.textContent();
+      expect(text!.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('TOC becomes visible after scrolling past header', async ({ page }) => {
+    // TOC starts hidden (not visible class) when at top
+    const toc = page.locator('.post-toc');
+
+    // Scroll past the header section
+    await page.evaluate(() => {
+      const header = document.querySelector('.header-section');
+      if (header) {
+        const bottom = header.getBoundingClientRect().bottom + window.scrollY + 50;
+        window.scrollTo({ top: bottom });
+      }
+    });
+    await page.waitForTimeout(300);
+
+    await expect(toc).toHaveClass(/post-toc--visible/);
+  });
+
+  test('clicking TOC link scrolls to the heading', async ({ page }) => {
+    // Make TOC visible first
+    await page.evaluate(() => window.scrollTo({ top: 500 }));
+    await page.waitForTimeout(300);
+
+    const firstLink = page.locator('.post-toc-link').first();
+    const targetId = await firstLink.getAttribute('data-target');
+    expect(targetId).toBeTruthy();
+
+    // On narrow viewports the TOC is a bottom sheet — open it first if needed
+    const toggle = page.locator('.post-toc-toggle');
+    if (await toggle.isVisible()) {
+      await toggle.click();
+      await page.waitForTimeout(400);
+    }
+
+    await firstLink.click({ force: true });
+
+    // Wait for smooth scroll to finish
+    await page.waitForTimeout(1000);
+
+    // The target heading should be near the top of the viewport
+    const headingY = await page.evaluate((id) => {
+      const el = document.getElementById(id!);
+      return el ? el.getBoundingClientRect().top : 999;
+    }, targetId);
+
+    // Should be within ~120px of the top (accounting for navbar offset)
+    expect(headingY).toBeLessThan(150);
+    expect(headingY).toBeGreaterThan(-20);
+  });
+
+  test('active section highlights on scroll', async ({ page }) => {
+    // Scroll to trigger visibility and section tracking
+    await page.evaluate(() => window.scrollTo({ top: 800 }));
+    await page.waitForTimeout(500);
+
+    // At least one link should have the active class
+    const activeLinks = page.locator('.post-toc-link.active');
+    await expect(activeLinks.first()).toBeAttached({ timeout: 3000 });
+  });
+
+  test('TOC header shows "On this page"', async ({ page }) => {
+    const title = page.locator('.post-toc-title');
+    await expect(title).toHaveText('On this page');
+  });
+
+  test('TOC has proper ARIA label', async ({ page }) => {
+    const toc = page.locator('.post-toc');
+    await expect(toc).toHaveAttribute('aria-label', 'Table of contents');
+  });
+
+  test('h3 headings are indented (nested style)', async ({ page }) => {
+    // Check if any nested items exist (h3s render with nested class)
+    const nestedItems = page.locator('.post-toc-item--nested');
+    const count = await nestedItems.count();
+    // Not all posts have h3s, so this is valid at 0
+    expect(count).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test.describe('Post TOC - posts with few headings', () => {
+  test('TOC does not appear on homepage (no .blog-post)', async ({ page }) => {
+    await page.goto('');
+    await page.waitForTimeout(500);
+
+    // Homepage has no .blog-post, so TOC should not be created
+    const toc = page.locator('.post-toc');
+    await expect(toc).not.toBeAttached();
+
+    const progressBar = page.locator('.reading-progress');
+    await expect(progressBar).not.toBeAttached();
+  });
+});
+
+test.describe('Post TOC - mobile behavior', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('mobile toggle button appears on scroll', async ({ page }) => {
+    await page.goto(POST_WITH_HEADINGS);
+    await page.waitForSelector('.post-toc-toggle', { timeout: 10000 });
+
+    // Scroll past header
+    await page.evaluate(() => window.scrollTo({ top: 600 }));
+    await page.waitForTimeout(300);
+
+    const toggle = page.locator('.post-toc-toggle');
+    await expect(toggle).toHaveClass(/post-toc-toggle--visible/);
+  });
+
+  test('tapping toggle opens TOC on mobile', async ({ page }) => {
+    await page.goto(POST_WITH_HEADINGS);
+    await page.waitForSelector('.post-toc-toggle', { timeout: 10000 });
+
+    // Scroll to make toggle visible
+    await page.evaluate(() => window.scrollTo({ top: 600 }));
+    await page.waitForTimeout(300);
+
+    const toggle = page.locator('.post-toc-toggle');
+    await toggle.click();
+
+    const toc = page.locator('.post-toc');
+    await expect(toc).toHaveClass(/post-toc--expanded/);
+  });
+});


### PR DESCRIPTION
## What this PR does

Adds a **floating Table of Contents** and **reading progress bar** to blog posts -- auto-generated, zero config, mobile-friendly.

### Features

- **Reading progress bar** -- thin orange gradient bar fixed at the top of the viewport, fills as you scroll through the post
- **Auto-generated TOC** -- scans h2/h3 headings from `.blog-post` and builds a navigable sidebar labeled "On this page"
- **Active section highlighting** -- Intersection Observer tracks which section is in view and highlights it in the TOC with an orange accent
- **Smooth-scroll navigation** -- clicking a TOC link scrolls to that heading with navbar offset, updates URL hash
- **Smart visibility** -- TOC slides in only after scrolling past the post header; hidden on posts with fewer than 3 headings
- **Mobile bottom sheet** -- on tablets/phones, TOC opens as a bottom sheet with dark backdrop scrim, drag handle, and tap-outside-to-dismiss
- **Accessible** -- `aria-label`, `role="progressbar"`, reduced-motion support

### Files

**New:**
- `assets/js/post-toc.js` -- vanilla JS (230 lines), no dependencies
- `tests/post-toc.spec.ts` -- 12 Playwright tests

**Modified:**
- `_layouts/base.html` -- added script tag
- `assets/css/blog.css` -- +273 lines (progress bar, floating TOC, responsive bottom sheet)
- `tests/command-palette.spec.ts` -- fixed flaky keyboard navigation test (debounce settle wait)

### Tests
12 new TOC tests + 1 flaky test fix. **49/49 pass.**
