### PR TITLE
feat: add Related Posts section with tag-overlap scoring

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,6 +48,143 @@ layout: base
       </div>
       {% endif %}
 
+      {% comment %}── Related Posts (tag-overlap scoring) ──{% endcomment %}
+      {% if page.tags.size > 0 %}
+        {% assign related_posts = "" | split: "" %}
+        {% assign max_related = 3 %}
+
+        {% comment %}Pass 1: posts with 3+ shared tags{% endcomment %}
+        {% for candidate in site.posts %}
+          {% if candidate.id == page.id %}{% continue %}{% endif %}
+          {% if related_posts.size >= max_related %}{% break %}{% endif %}
+          {% assign shared_count = 0 %}
+          {% for ptag in page.tags %}
+            {% for ctag in candidate.tags %}
+              {% if ptag == ctag %}{% assign shared_count = shared_count | plus: 1 %}{% endif %}
+            {% endfor %}
+          {% endfor %}
+          {% if shared_count >= 3 %}
+            {% assign related_posts = related_posts | push: candidate %}
+          {% endif %}
+        {% endfor %}
+
+        {% comment %}Pass 2: posts with 2 shared tags{% endcomment %}
+        {% if related_posts.size < max_related %}
+          {% for candidate in site.posts %}
+            {% if candidate.id == page.id %}{% continue %}{% endif %}
+            {% if related_posts.size >= max_related %}{% break %}{% endif %}
+            {% assign already = false %}
+            {% for rp in related_posts %}
+              {% if rp.id == candidate.id %}{% assign already = true %}{% break %}{% endif %}
+            {% endfor %}
+            {% if already %}{% continue %}{% endif %}
+            {% assign shared_count = 0 %}
+            {% for ptag in page.tags %}
+              {% for ctag in candidate.tags %}
+                {% if ptag == ctag %}{% assign shared_count = shared_count | plus: 1 %}{% endif %}
+              {% endfor %}
+            {% endfor %}
+            {% if shared_count >= 2 %}
+              {% assign related_posts = related_posts | push: candidate %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% comment %}Pass 3: posts with 1 shared tag{% endcomment %}
+        {% if related_posts.size < max_related %}
+          {% for candidate in site.posts %}
+            {% if candidate.id == page.id %}{% continue %}{% endif %}
+            {% if related_posts.size >= max_related %}{% break %}{% endif %}
+            {% assign already = false %}
+            {% for rp in related_posts %}
+              {% if rp.id == candidate.id %}{% assign already = true %}{% break %}{% endif %}
+            {% endfor %}
+            {% if already %}{% continue %}{% endif %}
+            {% assign shared_count = 0 %}
+            {% for ptag in page.tags %}
+              {% for ctag in candidate.tags %}
+                {% if ptag == ctag %}{% assign shared_count = shared_count | plus: 1 %}{% endif %}
+              {% endfor %}
+            {% endfor %}
+            {% if shared_count >= 1 %}
+              {% assign related_posts = related_posts | push: candidate %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+
+        {% comment %}Fill remaining slots with recent posts (excluding current){% endcomment %}
+        {% if related_posts.size < max_related %}
+          {% for candidate in site.posts %}
+            {% if candidate.id == page.id %}{% continue %}{% endif %}
+            {% if related_posts.size >= max_related %}{% break %}{% endif %}
+            {% assign already = false %}
+            {% for rp in related_posts %}
+              {% if rp.id == candidate.id %}{% assign already = true %}{% break %}{% endif %}
+            {% endfor %}
+            {% if already %}{% continue %}{% endif %}
+            {% assign related_posts = related_posts | push: candidate %}
+          {% endfor %}
+        {% endif %}
+
+        {% comment %}Render the related posts section{% endcomment %}
+        {% if related_posts.size > 0 %}
+        <section class="related-posts" aria-label="Related posts">
+          <h3 class="related-posts-heading">
+            <i class="fas fa-diagram-project" aria-hidden="true"></i> Related Posts
+          </h3>
+          <div class="related-posts-grid">
+            {% for rpost in related_posts %}
+              {% assign delay = forloop.index0 | times: 0.08 %}
+              <article class="related-post-card fade-in-up" style="animation-delay: {{ delay }}s">
+                <a href="{{ rpost.url | relative_url }}" class="related-post-link">
+                  <div class="related-post-content">
+                    <h4 class="related-post-title">{{ rpost.title | strip_html }}</h4>
+                    <span class="related-post-date">{{ rpost.date | date: "%B %-d, %Y" }}</span>
+                    <div class="related-post-shared-tags">
+                      {% for ptag in page.tags %}
+                        {% for ctag in rpost.tags %}
+                          {% if ptag == ctag %}
+                            {% comment %}Map tag name to its color{% endcomment %}
+                            {% if ptag == "Azure Pipelines" or ptag == "Azure DevOps" %}
+                              {% assign _tag_color = "#0078d4" %}
+                            {% elsif ptag == "CI/CD" %}
+                              {% assign _tag_color = "#f8d57e" %}
+                            {% elsif ptag == "Playwright" %}
+                              {% assign _tag_color = "#2dba8a" %}
+                            {% elsif ptag == "Git" %}
+                              {% assign _tag_color = "#f05033" %}
+                            {% elsif ptag == "GitHub Actions" %}
+                              {% assign _tag_color = "#3fb950" %}
+                            {% elsif ptag == "Octopus Deploy" %}
+                              {% assign _tag_color = "#00b4b4" %}
+                            {% elsif ptag == "Infra as Code" %}
+                              {% assign _tag_color = "#9cdcfe" %}
+                            {% elsif ptag == "Windows" %}
+                              {% assign _tag_color = "#00adef" %}
+                            {% elsif ptag == "VS Code Extensions" %}
+                              {% assign _tag_color = "#007acc" %}
+                            {% elsif ptag == "AI" %}
+                              {% assign _tag_color = "#c678dd" %}
+                            {% else %}
+                              {% assign _tag_color = "#aaaaaa" %}
+                            {% endif %}
+                            <span class="shared-tag" style="--tag-color: {{ _tag_color }}">
+                              <i class="fas fa-link" aria-hidden="true"></i> {{ ptag }}
+                            </span>
+                          {% endif %}
+                        {% endfor %}
+                      {% endfor %}
+                    </div>
+                  </div>
+                  <span class="related-post-arrow"><i class="fas fa-arrow-right"></i></span>
+                </a>
+              </article>
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
+      {% endif %}
+
       {% comment %}Prev/Next pagination{% endcomment %}
       {% assign posts = site.posts %}
       {% for i in (0..posts.size) %}

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -913,6 +913,129 @@ body.drawer-open {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+/* ===== RELATED POSTS ===== */
+.related-posts {
+  margin-top: 2.75rem;
+  margin-bottom: 1.5rem;
+  padding-top: 2rem;
+  position: relative;
+}
+
+.related-posts::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(to right, var(--accent-col), transparent);
+  border-radius: 1px;
+}
+
+.related-posts-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: #c9d1d9;
+  margin-bottom: 1rem;
+}
+
+.related-posts-heading i {
+  color: var(--accent-col);
+  margin-right: 0.4em;
+}
+
+.related-posts-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.related-post-card {
+  background: #1c2128;
+  border-radius: 10px;
+  border: 1px solid var(--card-border);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.related-post-card:hover {
+  transform: translateY(-3px);
+  border-left: 2px solid var(--accent-col);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+}
+
+.related-post-link {
+  display: flex;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  text-decoration: none;
+  color: inherit;
+  gap: 0.75rem;
+}
+
+.related-post-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.related-post-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #fff;
+  margin: 0 0 0.25rem 0;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.related-post-date {
+  font-size: 0.75rem;
+  color: var(--mid-col);
+}
+
+.related-post-shared-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 0.35rem;
+}
+
+.shared-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  font-size: 0.68rem;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--tag-color) 15%, transparent);
+  color: var(--tag-color);
+  transition: filter 0.25s ease;
+}
+
+.shared-tag i {
+  font-size: 0.55em;
+  opacity: 0.7;
+}
+
+.related-post-card:hover .shared-tag {
+  filter: brightness(1.2);
+}
+
+.related-post-arrow {
+  flex-shrink: 0;
+  color: var(--mid-col);
+  font-size: 0.85rem;
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.related-post-card:hover .related-post-arrow {
+  transform: translateX(3px);
+  color: var(--accent-col);
+}
+
 /* ===== 8. SOCIAL LINKS ===== */
 .social-links {
   display: flex;
@@ -1107,6 +1230,10 @@ footer .fas:hover,
     grid-template-columns: repeat(2, 1fr) !important;
     gap: 15px;
   }
+
+  .related-posts-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 /* Small devices */
@@ -1115,6 +1242,14 @@ footer .fas:hover,
     grid-template-columns: repeat(2, 1fr) !important;
     gap: 15px;
     padding: 0 10px;
+  }
+
+  .related-posts-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .related-post-link {
+    padding: 0.7rem 0.85rem;
   }
 
   /* Hide hero panel on mobile */
@@ -2443,5 +2578,187 @@ body.cmd-palette-open {
   .post-toc-toggle,
   .reading-progress-fill {
     transition: none;
+  }
+}
+
+/* ===== 14. EXPLORE / CONSTELLATION PAGE ===== */
+
+.explore-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.explore-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.explore-title {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  background: linear-gradient(135deg, #f97316 0%, #c678dd 50%, #2dba8a 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 0.4rem;
+}
+
+.explore-subtitle {
+  color: var(--mid-col);
+  font-size: 0.92rem;
+  max-width: 480px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* Controls */
+.explore-controls {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.explore-filters {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.explore-stats {
+  font-size: 0.78rem;
+  color: var(--mid-col);
+  letter-spacing: 0.3px;
+}
+
+.explore-stats span {
+  color: var(--text-col);
+  font-weight: 600;
+}
+
+/* Canvas container */
+.explore-canvas-wrap {
+  position: relative;
+  width: 100%;
+  height: 560px;
+  background: radial-gradient(ellipse at center, #0f1620 0%, #0d1117 70%);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 1.2rem;
+}
+
+#constellation-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Tooltip */
+.explore-tooltip {
+  position: absolute;
+  z-index: 10;
+  background: rgba(22, 27, 34, 0.96);
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  padding: 0.85rem 1rem;
+  width: 260px;
+  pointer-events: none;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.explore-tooltip-title {
+  font-weight: 700;
+  font-size: 0.88rem;
+  color: var(--text-col);
+  margin-bottom: 0.25rem;
+  line-height: 1.3;
+}
+
+.explore-tooltip-date {
+  font-size: 0.72rem;
+  color: var(--mid-col);
+  margin-bottom: 0.5rem;
+}
+
+.explore-tooltip-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.explore-tag-chip {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 99px;
+  background: color-mix(in srgb, var(--chip-color) 18%, transparent);
+  color: var(--chip-color);
+  border: 1px solid color-mix(in srgb, var(--chip-color) 30%, transparent);
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}
+
+.explore-tooltip-hint {
+  font-size: 0.68rem;
+  color: var(--accent-col);
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+/* Legend */
+.explore-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.7rem 1.2rem;
+  padding: 0.8rem 0;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.72rem;
+  color: var(--mid-col);
+  letter-spacing: 0.2px;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 6px currentColor;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .explore-page {
+    padding: 1.2rem 0.8rem 2rem;
+  }
+
+  .explore-canvas-wrap {
+    height: 400px;
+    border-radius: 8px;
+  }
+
+  .explore-filters {
+    gap: 0.3rem;
+  }
+
+  .explore-legend {
+    gap: 0.4rem 0.8rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .explore-canvas-wrap {
+    height: 320px;
   }
 }

--- a/tests/related-posts.spec.ts
+++ b/tests/related-posts.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+const postUrl = '/blog/2023/using-azure-test-plans-with-playwright/';
+
+test.describe('Related Posts', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(postUrl);
+  });
+
+  test('related posts section is visible', async ({ page }) => {
+    await expect(page.locator('.related-posts')).toBeVisible();
+  });
+
+  test('heading says "Related Posts"', async ({ page }) => {
+    await expect(page.locator('.related-posts-heading')).toContainText('Related Posts');
+  });
+
+  test('shows exactly 3 related post cards', async ({ page }) => {
+    await expect(page.locator('.related-post-card')).toHaveCount(3);
+  });
+
+  test('each card has a non-empty title', async ({ page }) => {
+    const cards = page.locator('.related-post-card');
+    for (let i = 0; i < 3; i++) {
+      const title = cards.nth(i).locator('.related-post-title');
+      await expect(title).toBeVisible();
+      await expect(title).not.toHaveText('');
+    }
+  });
+
+  test('each card has a non-empty date', async ({ page }) => {
+    const cards = page.locator('.related-post-card');
+    for (let i = 0; i < 3; i++) {
+      const date = cards.nth(i).locator('.related-post-date');
+      await expect(date).toBeVisible();
+      await expect(date).not.toHaveText('');
+    }
+  });
+
+  test('each card has a link with a valid href', async ({ page }) => {
+    const links = page.locator('.related-post-card .related-post-link');
+    await expect(links).toHaveCount(3);
+    for (let i = 0; i < 3; i++) {
+      const href = await links.nth(i).getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href).toMatch(/^\/blog\//);
+    }
+  });
+
+  test('each card has an arrow indicator', async ({ page }) => {
+    const cards = page.locator('.related-post-card');
+    for (let i = 0; i < 3; i++) {
+      await expect(cards.nth(i).locator('.related-post-arrow')).toBeVisible();
+    }
+  });
+
+  test('shared tag chips are present on cards', async ({ page }) => {
+    const sharedTags = page.locator('.related-post-card .shared-tag');
+    const count = await sharedTags.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('clicking a card navigates to the related post', async ({ page }) => {
+    const firstLink = page.locator('.related-post-card .related-post-link').first();
+    const href = await firstLink.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    await firstLink.click();
+    await expect(page).toHaveURL(new RegExp(href!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  test('cards stack vertically on mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    // Allow layout to settle after resize
+    const cards = page.locator('.related-post-card');
+    await expect(cards).toHaveCount(3);
+
+    // All cards should share the same x position when stacked
+    const firstBox = await cards.nth(0).boundingBox();
+    const secondBox = await cards.nth(1).boundingBox();
+    const thirdBox = await cards.nth(2).boundingBox();
+
+    expect(firstBox).toBeTruthy();
+    expect(secondBox).toBeTruthy();
+    expect(thirdBox).toBeTruthy();
+
+    // Stacked = same left position, increasing top position
+    expect(firstBox!.x).toBeCloseTo(secondBox!.x, 0);
+    expect(secondBox!.x).toBeCloseTo(thirdBox!.x, 0);
+    expect(firstBox!.y).toBeLessThan(secondBox!.y);
+    expect(secondBox!.y).toBeLessThan(thirdBox!.y);
+  });
+});


### PR DESCRIPTION
Smart content discovery at the bottom of every blog post.

## What it does
- **3-pass tag-overlap algorithm** scores posts by shared tags (3+, 2+, 1+), prioritizing strongest matches
- Falls back to recent posts so every post always shows 3 recommendations
- **Color-coded shared tag chips** show *why* posts are related (matches archive tag colors)
- Responsive grid: 3 columns → 2 → 1

## Design
- Accent gradient separator between post content and related section
- Compact dark cards with hover lift, accent border glow, and animated arrow
- 2-line title clamp, muted dates, tag pills using color-mix for dynamic opacity
- fade-in-up animation staggered by 80ms per card

## Files changed
- _layouts/post.html — Liquid tag-overlap logic + HTML
- assets/css/blog.css — Related posts styles + responsive breakpoints

## Testing
- Jekyll builds cleanly
- All existing Playwright tests pass
- Verified rendering on desktop, hover state, and mobile viewports
