### PR TITLE
ci: pin test-summary action to v2.6

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -50,7 +50,7 @@ jobs:
           npx playwright test
 
       - name: Create test summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.6
         if: always()
         with:
           paths: ./test-results/junit.xml


### PR DESCRIPTION
## Problem

The Playwright Tests workflow [run #546](https://github.com/MarcusFelling/blog/actions/runs/25534697986/job/74948032399) failed with:

```n##[error]File not found: '/home/runner/work/_actions/test-summary/action/v2/index.js'
```

All 59 Playwright tests passed, but the `Create test summary` step failed because the maintainer of `test-summary/action` recently moved the floating `v2` tag to a branch that did not contain the built `index.js`. They published `v2.6` to fix it, with the release note: *"Actually update the tag to point to the correct branch (dist) instead of the dev branch."*

## Change

Pin `test-summary/action` from `@v2` (floating) to `@v2.6` (specific release) in [.github/workflows/playwright.yml](.github/workflows/playwright.yml) to insulate the workflow from future breakage on the floating tag.