### PR TITLE
Fix flaky post-toc active-section test

### DIFF
--- a/tests/post-toc.spec.ts
+++ b/tests/post-toc.spec.ts
@@ -104,8 +104,19 @@ test.describe('Post Table of Contents + Reading Progress', () => {
   });
 
   test('active section highlights on scroll', async ({ page }) => {
-    // Scroll to trigger visibility and section tracking
-    await page.evaluate(() => window.scrollTo({ top: 800 }));
+    // Scroll past the first content heading so section tracking marks it active.
+    // Use the heading's real position (not a fixed pixel value) so the test is
+    // robust regardless of how tall the post header/hero is.
+    await page.evaluate(() => {
+      const post = document.querySelector('.blog-post');
+      const heading = post?.querySelector('h2, h3');
+      if (heading) {
+        const top = heading.getBoundingClientRect().top + window.scrollY;
+        window.scrollTo({ top: top + 100 });
+      } else {
+        window.scrollTo({ top: 800 });
+      }
+    });
     await page.waitForTimeout(500);
 
     // At least one link should have the active class


### PR DESCRIPTION
## Problem

The scheduled [Playwright run](https://github.com/MarcusFelling/blog/actions/runs/27393738651) failed on `tests/post-toc.spec.ts` -> `active section highlights on scroll` with `expect(locator).toBeAttached()` timing out: no `.post-toc-link.active` element appeared.

## Root cause

The test scrolled to a hardcoded `top: 800`, but the TOC active-section logic only marks a heading active when its absolute top is `<= window.scrollY + 81`. On posts with a tall hero/header, the first heading sits below ~881px, so no link ever gains the `active` class -- a fragile, content-dependent assertion.

## Fix

Scroll relative to the first actual content heading (its real position + 100px) instead of a fixed pixel value, guaranteeing a heading crosses the activation threshold regardless of header height.

Verified the previously-failing test now passes locally.