### PR TITLE
Fix homepage excerpt for AI-analyst post

### DIFF
--- a/_posts/2026-07-07-vibe-analytics-should-scare-you.md
+++ b/_posts/2026-07-07-vibe-analytics-should-scare-you.md
@@ -3,6 +3,7 @@ id: 1289
 title: 'An AI Analyst That Shows Its Work'
 date: '2026-07-07'
 description: 'A natural-language analyst that routes plain-English questions to the right governed model, applies the filters people would forget, runs the query under your identity, and shows its work. The twist: most of it is not AI. The real product is institutional knowledge, written down as markdown.'
+excerpt: 'A natural-language analyst that routes plain-English questions to the right governed model, applies the filters people would forget, runs the query under your identity, and shows its work.'
 layout: post
 guid: 'https://marcusfelling.com/?p=1289'
 permalink: /blog/2026/ai-analyst-that-shows-its-work


### PR DESCRIPTION
Follow-up to #85.

Adds an explicit `excerpt` to the post's front matter. Without it, Jekyll builds the homepage card preview from the first paragraph, which is now just the lead-in `To set some context:` (the vibe-coding/analytics points became a bullet list below it), so the card showed that one cut-off line.

The excerpt reuses the first sentence of the existing `description` so the card shows a complete summary.