### PR TITLE
Apply Stop Slop edits to four blog posts

### DIFF
--- a/_posts/2026-01-20-what-three-day-hackathon-taught-me-shipping-ai-agent-mvps-real-stakeholders.md
+++ b/_posts/2026-01-20-what-three-day-hackathon-taught-me-shipping-ai-agent-mvps-real-stakeholders.md
@@ -1,8 +1,8 @@
 ---
 id: 1276
-title: 'Shipping an AI Agent MVP: What Actually Worked'
+title: 'Shipping an AI Agent MVP: What Worked'
 date: '2026-01-20'
-description: 'Shipping an AI Agent MVP: What Actually Worked'
+description: 'Shipping an AI Agent MVP: What Worked'
 layout: post
 guid: 'https://marcusfelling.com/?p=1276'
 permalink: /blog/2026/three-day-hackathon-shipping-ai-agent-mvps
@@ -11,58 +11,56 @@ nav-short: true
 tags: [AI]
 ---
 
-I recently led a 3 day hackathon to build an AI solution that streamlines our monthly business reviews for our Microsoft direct sales ecommerce store (think Surface devices, M365, Xbox). Our team had been spending way too much time talking at high levels and planning what to build; this was an opportunity to dive in and start executing. In this post I'll summarize the practical lessons learned from the experience.
+I led a three-day hackathon to build an AI solution that streamlines monthly business reviews for our Microsoft direct-sales ecommerce store, including Surface devices, Microsoft 365, and Xbox. Our team had spent too much time on high-level planning. The hackathon gave us three days to move from planning to execution.
 
-To set some context, our team builds on [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/fundamentals/microsoft-fabric-overview) (data analytics SaaS platform) which recently announced [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview) that included new features/capabilities such as Ontology and Data Agents, so the timing worked out great to kick the tires on what's actually possible in practice.
+Our team builds on [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/fundamentals/microsoft-fabric-overview), a data analytics SaaS platform. Microsoft announced [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview), including Ontology and Data Agents, before the hackathon, so we tested those capabilities in a real scenario.
 
 ---
 
 ## TL;DR
 
-- **Start with the real problem**, not the tools
-- **Cut scope ruthlessly** and ship something valuable, not everything
-- **Keep the delivery simple** while you're figuring out if it even works
+- **Start with the business problem**
+- **Cut scope to a useful MVP**
+- **Use a simple delivery path for the first test**
 - **Break big agents into smaller**, more focused sub agents
 - **Engage stakeholders** throughout the process
 - **Test often** and iterate fast
 
 ## Begin With a Clear Business Problem
 
-Instead of jumping straight into tool selection, we focused on understanding the problem first. Before the hack, we had a brainstorming session to come up with a list of high impact use cases we could tackle. We landed on preparing monthly business reviews, specifically, analyzing KPI shifts, and writing up narratives. This takes our team a lot of time (hundreds of hours) and a lot of it gets repeated every single month. That helped us figure out what actually needed automating and what value an AI agent could realistically add in three days.
+We began by defining the problem. Before the hack, we listed candidate use cases and chose monthly business review preparation: analyzing KPI shifts and writing narratives. The team spends hundreds of hours on this work each month. We used that scope to identify what needed automation and what an AI agent could deliver in three days.
 
-When we talked to stakeholders, they were pretty clear about what they needed: spot the biggest KPI moves, connect those changes to contextual factors, and provide concise summaries for leadership review. Those requirements told us which agent capabilities actually mattered and confirmed that building KPI and commentary prototypes was worth the effort.
+Stakeholders asked us to spot the biggest KPI moves, connect those changes to contextual factors, and provide concise summaries for leadership review. We used those requirements to prioritize KPI analysis and commentary prototypes.
 
-## Reduce Scope Early and Create a Practical MVP
+## Reduce Scope and Create a Practical MVP
 
-There are a ton of options when it comes to user experience and how stakeholders would interact with our agents. To keep it simple, we decided the MVP would generate insights on a schedule and deliver them by email. It was more important that we get the outputs in the hands of the stakeholders ASAP to provide feedback and validate, than spend a bunch of time on a polished interface that provided garbage outputs.
+We needed a way for stakeholders to receive the agent's output. For the MVP, we scheduled insight generation and delivered the result by email. Email put outputs in stakeholders' hands fast, so they could validate the content before we invested in a polished interface.
 
-From a tooling perspective, this allowed us to leverage tools we already had experience with to move fast: we chose Logic Apps to orchestrate Fabric data agents, passing outputs as variables, and merging them together to send the final email. There was quite a learning curve that came with ramping up on AI native orchestrators (Copilot Studio, AI Foundry, etc.) and environment setup, that just wasn't realistic for a 3 day timeline.
+We also chose tools we knew. Logic Apps orchestrated the Fabric data agents, passed outputs as variables, and merged them into the final email. Learning Copilot Studio or AI Foundry and setting up their environments would have consumed most of the three-day hackathon.
 
 ## Break Big Agents Into Smaller, More Focused Sub Agents
 
-We started with a plan for two big agents: one for KPI analysis, one for writing narratives. As we threw more and more data sources at our agents, we found their accuracy turned to slop. We moved to finely scoped sub agents that were specialized for their tasks. We stripped out tables and measures we didn't need, cleaned up the filtering logic, and set the agents to use narrower data sources. Those tweaks stabilized things and made sure each piece was actually doing what it was supposed to do. When we split up the work and trimmed unnecessary complexity from the agents, **accuracy went way up**. We now have 6 (and growing) specialized agents...
+We started with a plan for two big agents: one for KPI analysis and one for writing narratives. As we added data sources, their accuracy turned to slop. We split them into specialized subagents with narrow scopes. We stripped out tables and measures we didn't need, cleaned up the filtering logic, and set the agents to use narrower data sources. Narrowing the scope this way stabilized the output and improved accuracy. The prototype grew to six specialized agents.
 
 ### Lessons Learned: Fabric Data Agents
 
-Specific to Fabric data agents, we experienced issues like using incorrect DAX queries and tables/columns that weren't even in scope. To overcome this, we implemented a few practices:
+Fabric data agents sometimes generated incorrect DAX or referenced tables and columns outside their scope. We responded with four practices:
 
 > **Good Practices for Fabric Data Agents:**
 > 
-> - Keep the Semantic Model as clear as possible, especially custom DAX measures
+> - Keep the semantic model and its custom DAX measures clear
 > - Use the [Prepare your data for AI](https://learn.microsoft.com/en-us/power-bi/create-reports/copilot-prepare-data-ai) tool on the published semantic model
-> - Select only the essential measures and tables when creating the agent
+> - Select the essential measures and tables when creating the agent
 > - Provide explicit instructions to the agent about when it should perform its own calculations
 
 ## Engage Stakeholders Throughout the Process
 
-Having stakeholders involved throughout the hackathon was **extremely valuable**. This helped us continuously validate what we were building and speed up the feedback loop. Which KPI moves actually mattered, how they wanted the summaries written, and what context was missing, etc. Bringing them in early meant we didn't waste time building stuff nobody wanted. We could pivot fast based on what they told us.
-
-> **Key Insight:** Early stakeholder engagement turned potential weeks of rework into hours of quick adjustments. Their feedback directly shaped which agents we prioritized and how we structured the outputs.
+Stakeholders reviewed the work throughout the hackathon, which shortened the feedback loop. They told us which KPI moves mattered, how they wanted the summaries written, and what context was missing. Their early feedback kept us from building features nobody wanted and let us adjust the prototypes during the hackathon.
 
 ---
 
 ## Closing Thoughts
 
-Three days gave us a chance to see what AI-powered agents could actually do. And honestly, it showed that with a tight timeline, you can still ship something real if you **nail the problem**, **keep scope tight**, and **iterate like crazy**.
+In three days, we tested AI agents against a real monthly-review workflow. A clear problem and tight scope let us ship a working prototype. Stakeholder feedback guided each adjustment.
 
-Since the hackathon, we've come a long way with our solution but this gave us a jump start on the work.
+The three-day prototype gave us the starting point for the solution we continued to build.

--- a/_posts/2026-02-26-building-an-ai-agent-squad-for-your-repo.md
+++ b/_posts/2026-02-26-building-an-ai-agent-squad-for-your-repo.md
@@ -11,13 +11,13 @@ nav-short: true
 tags: [AI]
 ---
 
-What if your repo had a whole team of AI agents: a lead, a frontend dev, a tester, a content writer, each with their own context window, persistent memory, and defined boundaries? That's exactly what [Squad](https://github.com/bradygaster/squad) gives you.
+[Squad](https://github.com/bradygaster/squad) gives your repo a team of AI agents: a lead, a frontend dev, a tester, and a content writer, each with a separate context window, persistent memory, and defined boundaries.
 
-[Squad](https://github.com/bradygaster/squad) is an open-source framework conceived by [Brady Gaster](https://github.com/bradygaster) that creates an AI development team through GitHub Copilot. You describe what you're building, and Squad proposes a team of specialists that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and get better the more you use them.
+[Brady Gaster](https://github.com/bradygaster) created the open-source framework to build AI development teams through GitHub Copilot. You describe what you're building, and Squad proposes a team of specialists that live in your repo as files. They persist across sessions, learn your codebase, share decisions, and improve as you use them.
 
-This isn't one chatbot swapping hats between answers. Each team member runs in its own context, reads only its own knowledge, and writes back what it learned.
+Each team member runs in its own context, reads its own knowledge, and writes back what it learned.
 
-I set it up for the repo of this blog. Here's what I learned.
+I set it up for the repo behind this blog.
 
 ## Installing Squad
 
@@ -36,7 +36,7 @@ Then open Copilot in VS Code, type `@squad`, and tell it what you're building:
 I'm starting a new project. Set up the team.
 ```
 
-Squad proposes a team, each member named from a persistent thematic cast. You say yes. They're ready.
+Squad proposes a team with names from a persistent thematic cast. Once you approve it, the team is ready.
 
 ## The Team
 
@@ -49,9 +49,9 @@ Squad generated a team tailored to my blog's needs:
 - 📋 **Scribe** / Session logger: decisions, session summaries
 - 🔄 **Ralph** / Work monitor: backlog, issue triage, CI monitoring
 
-The names come from a persistent casting system. Once assigned, they stick. Anyone who clones the repo gets the same team with the same cast.
+The casting system keeps each name after assignment, so a teammate who clones the repo gets the same team and cast.
 
-Each agent has a **charter** (`charter.md`) that defines scope and boundaries: what they own, what files they can modify, and critically, what they *don't* touch. Kaylee owns CSS but never writes tests. Wash owns blog posts but never touches layout. These boundaries prevent agents from stepping on each other.
+Each agent has a **charter** (`charter.md`) that defines scope and boundaries: what they own, what files they can modify, and what they *don't* touch. Kaylee owns CSS but never writes tests. Wash owns blog posts but never touches layout. These boundaries prevent agents from stepping on each other.
 
 ## What Gets Created
 
@@ -80,11 +80,11 @@ Everything lives in a `.squad/` directory:
 └── log/               # Session history
 ```
 
-Commit this folder. Your team persists. Names persist. It's all in git.
+Commit this folder, and the team's names and knowledge persist in git.
 
 ## Parallel Agents, Not Sequential
 
-This is the part I didn't see coming. When you give Squad a task, the coordinator launches every agent that can usefully start, all at the same time:
+I did not expect Squad to run work in parallel. When you give it a task, the coordinator launches all relevant agents at once:
 
 ```text
 You: "Team, redesign the blog"
@@ -94,9 +94,9 @@ You: "Team, redesign the blog"
   📋 Scribe → logging everything
 ```
 
-When agents finish, the coordinator immediately chains follow-up work. Tests reveal edge cases, another agent picks them up, no waiting for you to ask.
+As agents finish, the coordinator chains follow-up work. A test can expose an edge case, and another agent can pick it up without waiting for you to ask.
 
-Each agent gets its own context window. With Claude Sonnet 4 or Claude Opus 4's 200K token window, and the coordinator kept thin, each agent has ~78–83% of its context available for actual work. Fan out to 5 agents and you're working with ~1M tokens of total reasoning capacity.
+Each agent gets its own context window. With Claude Sonnet 4 or Claude Opus 4's 200K token window, a lightweight coordinator leaves each agent ~78–83% of its context for project work. Fan out to 5 agents and you're working with ~1M tokens of total reasoning capacity.
 
 ## Knowledge That Compounds
 
@@ -117,16 +117,16 @@ Framework, first cases → Edge case catalog → Regression patterns, coverage g
 
 Squad ties into GitHub Issues with a labeling workflow:
 
-1. Label an issue `squad`. The Lead auto-triages it, determines who should handle it, and applies the right `squad:{member}` label.
-2. The assigned member picks up the issue in their next Copilot session (or automatically if Copilot coding agent is enabled).
-3. Labels sync automatically from your team roster via the `sync-squad-labels` workflow.
+1. Label an issue `squad`. The Lead triages it, determines who should handle it, and applies the right `squad:{member}` label.
+2. The assigned member picks up the issue in their next Copilot session. Copilot coding agent can pick it up sooner when enabled.
+3. The `sync-squad-labels` workflow syncs labels from your team roster.
 
-## What I Learned
+## Lessons From Using It
 
 **The first session is the least capable.** Knowledge compounds. By the third or fourth session, agents were making decisions based on prior context without me having to repeat anything.
 
-**Boundaries matter more than capabilities.** Clear charters that define what an agent *doesn't* do are more important than what it can do. Overlap is the enemy.
+**Clear charters need explicit exclusions.** Define what each agent owns and what it cannot touch. That separation keeps agents from duplicating or conflicting with one another.
 
-**The Scribe quietly does the most valuable work.** Coming back the next day to a searchable log of every decision and session means I never have to reconstruct what past-me was thinking. Context doesn't get lost.
+**The Scribe does the most valuable work for me.** Its searchable log of decisions and sessions saves me from reconstructing what past-me was thinking the next day.
 
-If you're using GitHub Copilot for your repo(s) today, give Squad a try. The jump from one agent to a coordinated team is pretty awesome, and it all lives in git.
+If you're using GitHub Copilot for your repo today, give Squad a try. It splits work across separate contexts while keeping the team configuration in git.

--- a/_posts/2026-03-24-automating-meeting-action-items-into-azure-devops-with-mcp-and-copilot.md
+++ b/_posts/2026-03-24-automating-meeting-action-items-into-azure-devops-with-mcp-and-copilot.md
@@ -11,19 +11,19 @@ nav-short: true
 tags: [AI, Azure DevOps]
 ---
 
-My meetings produce action items. Most of the time, those action items should become work items in Azure DevOps. And between a meeting ending and me opening ADO to create them, there's a gap where my motivation goes to die.
+My meetings produce action items, and many belong in Azure DevOps. Between a meeting ending and me opening ADO to create them, there's a gap where my motivation goes to die.
 
-So I wired together GitHub Copilot, Work IQ, and Azure DevOps to pull meeting transcripts, extract action items, and draft work items for me to review before anything gets created or modified.
+I wired together GitHub Copilot, Work IQ, and Azure DevOps to pull meeting transcripts, extract action items, and draft work items for my review. I approve each draft before GitHub Copilot creates or changes a work item.
 
 ---
 
-**TL;DR**: I connected Work IQ MCP (reads Microsoft 365 meeting data) and Azure DevOps MCP (creates work items) to GitHub Copilot in VS Code. I record most of my meetings, so GitHub Copilot reads the transcript, extracts action items, and drafts ADO work items for me to review. I sign off before anything gets created or modified.
+**TL;DR**: I connected Work IQ MCP (reads Microsoft 365 meeting data) and Azure DevOps MCP (creates work items) to GitHub Copilot in VS Code. I record most of my meetings, so GitHub Copilot reads the transcript, extracts action items, and drafts ADO work items for me to review. I sign off before GitHub Copilot creates or changes anything.
 
 ---
 
 ## The Toolchain
 
-Four things wired together:
+The workflow combines four pieces:
 
 1. **[GitHub Copilot](https://code.visualstudio.com/docs/copilot/overview)** in VS Code: the orchestration layer. Runs the prompt, calls the MCP tools, handles the back-and-forth.
 2. **[Work IQ MCP](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview)**: reads my Microsoft 365 data (meetings, emails, Teams messages). This is where meeting context comes from.
@@ -32,38 +32,38 @@ Four things wired together:
 
 ## Work IQ: Reading Meeting Data
 
-[Work IQ](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview) is a Microsoft-built, first-party MCP server that exposes your Microsoft 365 work data — mail, calendar, Teams, files, people — as MCP tools.
+[Work IQ](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview) is a Microsoft-built, first-party MCP server that exposes your Microsoft 365 work data as MCP tools: mail, calendar, Teams, files, and people.
 
-How it works: you ask a natural-language question about your M365 data, the Work IQ MCP server translates that into Microsoft Graph requests behind the scenes, and you get structured data back. It runs under user-delegated permissions, so you're scoped to what you already have access to.
+Work IQ takes a natural-language question about your M365 data, translates it into Microsoft Graph requests, and returns structured data. It uses user-delegated permissions and accesses content available to you.
 
-It's a single MCP server that handles all M365 domains, not separate servers per data type. You query it the way you'd ask a person: "what happened in my last meeting with the platform team?" and it figures out the right Graph calls to make. Work IQ is currently in public preview, so the specific tools and APIs may shift.
+One MCP server handles all M365 domains. You query it the way you'd ask a person: "what happened in my last meeting with the platform team?" and it figures out the right Graph calls to make. Work IQ remains in public preview, so the specific tools and APIs may shift.
 
-For this project, meeting transcripts are what matter. I record most of my meetings, so the transcripts are sitting there in M365. Work IQ can pull the full transcript, which gives GitHub Copilot much richer context for extracting action items: who said what, what was actually agreed on, and what got left hanging. That level of detail is the difference between a useful work item and a vague one that nobody understands three weeks later.
+I use meeting transcripts for this project. I record most of my meetings, so the transcripts sit in M365. Work IQ pulls the full transcript, giving GitHub Copilot context about who said what, what people agreed to, and which items remained unresolved. I get enough detail to act on a draft three weeks later.
 
 ## Azure DevOps MCP: Creating Real Work Items
 
-The other half is the [Azure DevOps MCP server](https://github.com/microsoft/azure-devops-mcp). It gives GitHub Copilot the ability to perform actual ADO operations: creating work items and setting fields like title, description, assigned to, area path, iteration, and priority. Real items in the backlog, not a blob of JSON that I have to paste somewhere and tidy up by hand.
+The [Azure DevOps MCP server](https://github.com/microsoft/azure-devops-mcp) lets GitHub Copilot create work items and set fields such as title, description, assigned to, area path, iteration, and priority. It writes the items to the backlog, so I do not have to paste JSON somewhere and tidy it up by hand.
 
-## How It Actually Works
+## How It Works
 
-The flow:
+I use this six-step flow:
 
-1. A meeting happens. I try to record most meetings, the transcript is available in M365.
+1. I record most meetings, which makes their transcripts available in M365.
 2. I ask GitHub Copilot to pull the meeting transcript via Work IQ MCP.
 3. GitHub Copilot extracts the action items: who's responsible, what needs to happen, any deadlines mentioned.
 4. GitHub Copilot drafts the ADO work items and presents them to me for review.
-5. I review the draft. Edit titles and descriptions, remove anything that shouldn't be there. Then I approve.
-6. Only after I sign off does GitHub Copilot call the ADO MCP server to create the work items.
+5. I review the draft, edit titles and descriptions, and remove anything that should not be there.
+6. After I sign off, GitHub Copilot calls the ADO MCP server to create the work items.
 
-I don't let GitHub Copilot create work items unsupervised. Meetings are messy: speculative ideas, tangents, and the time-honored move of someone volunteering a colleague for work that colleague hasn't heard about yet. An AI reading a transcript can't reliably tell a real decision from someone thinking out loud. Someone who was actually in the room usually can.
+I don't let GitHub Copilot create work items unsupervised. Meetings are messy: speculative ideas, tangents, and the time-honored move of someone volunteering a colleague for work that colleague hasn't heard about yet. I was in the room, so I can separate real decisions from speculation during review.
 
-A couple of things I learned that help a lot:
+Two details reduce cleanup:
 
-**Reference your ADO org and project in your instructions file.** If you put your default org URL and project name in your custom instructions or `.github/copilot-instructions.md`, GitHub Copilot doesn't have to ask you every time. It just knows where to create work items. One less round-trip in every conversation.
+**Reference your ADO org and project in your instructions file.** Add your default organization URL and project name to your custom instructions or `.github/copilot-instructions.md`. GitHub Copilot can then target the right project without another round trip.
 
-**Point to a parent work item.** I usually reference the Epic I'm currently working under in my prompt. That way Copilot knows to create child Features, User Stories, or Tasks underneath it instead of dumping loose items into the backlog. Without this, you end up with orphaned work items that need manual reparenting. If your team structures work under Epics or Features, give GitHub Copilot that context upfront.
+**Point to a parent work item.** I include the Epic I'm working under in my prompt. Copilot can then create child Features, User Stories, or Tasks beneath it. Otherwise, Copilot may create orphaned work items that I have to reparent. If your team structures work under Epics or Features, give GitHub Copilot that context up front.
 
-In practice, a prompt looks something like:
+My prompt looks like this:
 
 ```text
 Read the transcript from my most recent meeting with 
@@ -72,38 +72,38 @@ Azure DevOps work items in the Platform project under
 Epic #4521. Show me the draft before creating anything.
 ```
 
-GitHub Copilot makes the Work IQ tool call, gets the transcript back, parses out action items, and shows me a structured draft. I make edits, say "looks good," and then GitHub Copilot makes the ADO MCP calls. You can watch the tool calls happening in real time in the GitHub Copilot chat.
+GitHub Copilot makes the Work IQ tool call, gets the transcript back, parses out action items, and shows me a structured draft. I make edits, say "looks good," and GitHub Copilot makes the ADO MCP calls. You can watch the tool calls in GitHub Copilot chat.
 
-> The interesting part isn't any single tool call. It's that GitHub Copilot handles the orchestration between two completely separate MCP servers in one conversation. Read from one system, get human approval, write to another.
+GitHub Copilot orchestrates two separate MCP servers in one conversation: it reads from one system, waits for my approval, and writes to another.
 
-## Why GitHub Copilot Over Copilot Cowork
+## Choosing GitHub Copilot Over Copilot Cowork
 
-This is the question I keep getting. Microsoft has [Copilot Cowork](https://www.microsoft.com/en-us/microsoft-365/blog/2026/03/09/copilot-cowork-a-new-way-of-getting-work-done/), built on [Claude Cowork](https://www.anthropic.com/product/claude-cowork), an enterprise work orchestration agent that can [plan multi-step tasks across M365](https://www.microsoft.com/en-us/microsoft-365/blog/2026/03/09/powering-frontier-transformation-with-copilot-and-agents/) (calendar, Teams, Excel, email) with basically zero setup. It supports [skills](https://claude.com/skills), [plugins](https://claude.com/plugins), and [MCP connectors](https://claude.com/connectors), so it's not short on extensibility. For one-off knowledge work across M365, it works well.
+Microsoft has [Copilot Cowork](https://www.microsoft.com/en-us/microsoft-365/blog/2026/03/09/copilot-cowork-a-new-way-of-getting-work-done/), built on [Claude Cowork](https://www.anthropic.com/product/claude-cowork), an enterprise work orchestration agent that can [plan multi-step tasks across M365](https://www.microsoft.com/en-us/microsoft-365/blog/2026/03/09/powering-frontier-transformation-with-copilot-and-agents/) across calendar, Teams, Excel, and email with little setup. It also supports [skills](https://claude.com/skills), [plugins](https://claude.com/plugins), and [MCP connectors](https://claude.com/connectors). For one-off knowledge work across M365, it works well.
 
-I went with GitHub Copilot + MCP for one main reason: it lives where my dev tools already are.
+I chose GitHub Copilot + MCP because it lives where my dev tools are.
 
 **Everything is in the repo.** My custom instructions, prompt files, and skill definitions are files that live in version control. I can diff them, review them in PRs, and share them across the team through normal git workflows. Cowork's skills and plugins exist in their own ecosystem outside of source control.
 
-**Built for developer workflows.** Cowork is designed for knowledge workers doing non-technical tasks across M365, and it's good at that. GitHub Copilot + MCP is designed for people who want to wire systems together programmatically, inspect tool calls, and iterate on prompts the way they iterate on code.
+**Built for developer workflows.** Cowork is designed for knowledge workers doing non-technical tasks across M365, and it's good at that. GitHub Copilot + MCP is designed for people who want to wire systems together through code, inspect tool calls, and iterate on prompts the way they iterate on code.
 
-They solve different problems. Cowork gives you zero-friction M365 orchestration with guardrails. GitHub Copilot + MCP gives you a developer-native platform where the customization lives in your repo and the workflow runs in your IDE. For repeatable workflows that need to reach into ADO and stay under version control, I'll take GitHub Copilot + MCP.
+Cowork handles M365 orchestration with built-in guardrails. GitHub Copilot + MCP gives you a developer-native platform where the customization lives in your repo and the workflow runs in your IDE. For repeatable workflows that need to reach into ADO and stay under version control, I'll take GitHub Copilot + MCP.
 
-## Where I'm Currently At
+## Current Results
 
-The setup works. I've run it against a handful of real meetings, and the output is good enough that I keep coming back to it. The drafts land around 80-90% right: I'll fix a title, delete the one item that was never really an action item, and tweak an assignment or two. The baseline is solid, and the review step keeps me in control.
+I've run the setup against a handful of real meetings. The drafts land around 80-90% right: I fix a title, delete an item that was never an action item, and tweak an assignment or two. The review step keeps me in control.
 
-The prompt file is versioned, the instructions are tuned for my ADO setup, and the whole thing runs in about 30 seconds of GitHub Copilot chat plus a minute of review. Beats the 15 minutes of copy-paste-and-forget that it replaced. Or the zero minutes I spent when I just forgot entirely.
+I keep the prompt file in version control and tune the instructions for my ADO setup. The workflow takes about 30 seconds of GitHub Copilot chat plus a minute of review. I used to spend 15 minutes copying and pasting, or zero minutes when I forgot the work.
 
-## What's Next
+## Packaging It for the Team
 
-Right now this lives in my prompt files and custom instructions. It works for me, but if I want other people on the team to use it, I need to package it up somehow.
+The workflow lives in my prompt files and custom instructions. To share it with the team, I need to package it as a reusable Copilot customization.
 
-GitHub Copilot has three mechanisms for this: [custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) (`.agent.md`), [prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files) (`.prompt.md`), and [skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills) (`SKILL.md`). They all live in the repo, version in git, and give the team a single file to iterate on. But they work differently, and the differences matter for something that creates real work items in an external system.
+GitHub Copilot offers three mechanisms for this: [custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) (`.agent.md`), [prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files) (`.prompt.md`), and [skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills) (`SKILL.md`). All three live in the repo, use git for versioning, and give the team a single file to iterate on. Their differences matter for a workflow that creates work items in an external system.
 
-I'm leaning toward a [custom agent](https://code.visualstudio.com/docs/copilot/customization/custom-agents). The main reason is tool restriction. An `.agent.md` file can restrict Copilot to only the tools you declare in frontmatter, so when someone invokes `@meeting-actions`, Copilot operates with only the Work IQ and ADO MCP tools. No stray tool calls against your codebase when the intent is "process a meeting." For a workflow that writes to a real system, scoped tool access matters from day one.
+I plan to use a [custom agent](https://code.visualstudio.com/docs/copilot/customization/custom-agents) because it supports tool restriction. An `.agent.md` file can restrict Copilot's tool set to declarations in frontmatter. When you invoke `@meeting-actions`, Copilot uses the Work IQ and ADO MCP tools without access to unrelated codebase tools. For a workflow that writes to a real system, scoped tool access matters from day one.
 
-Agents also let you bake in custom instructions, model preferences, and the human review step as part of the agent definition itself. The team invokes it with `@meeting-actions`, and everything about how the workflow runs is encapsulated in one file. The extraction logic, the field mappings, what counts as an action item vs. a discussion point, the "show me the draft before creating anything" gate.
+Agents also let you include custom instructions, model preferences, and the human review step in the agent definition. The team invokes it with `@meeting-actions`. One file contains the extraction logic, field mappings, definition of an action item, and the "show me the draft before creating anything" gate.
 
-A prompt file (`.prompt.md`) is the lighter alternative. It can declare MCP tool dependencies in frontmatter and you invoke it with `/meeting-work-items`. The difference is that prompt files don't restrict Copilot to only those tools. If you want to prototype the instructions first and don't need tool scoping yet, a prompt file is less conceptual overhead. And upgrading from a prompt file to an agent later is low-cost since the instructions body is the same Markdown either way.
+A prompt file (`.prompt.md`) is the lighter alternative. It can declare MCP tool dependencies in frontmatter, and you invoke it with `/meeting-work-items`. Prompt files leave Copilot's other tools available. If you want to prototype the instructions first and don't need tool scoping yet, a prompt file has less conceptual overhead. Moving from a prompt file to an agent costs little because the instructions body uses the same Markdown.
 
-Skills were actually my first instinct, but they're the weakest fit here. A `SKILL.md` gets auto-discovered by Copilot when it matches what you're asking about, which is useful for guidance and reusable patterns. But auto-discovery is a liability when the end result is writing work items to ADO. You can disable auto-discovery with `disable-model-invocation: true` in the frontmatter, but at that point you've turned a skill into a slash command without the tool restriction or model preference support that agents and prompt files offer. Skills also can't declare tool dependencies in machine-readable frontmatter. They reference tools in body text only.
+I considered skills first, but they fit this workflow least well. Copilot auto-discovers a `SKILL.md` when it matches your request, which helps with guidance and reusable patterns. Auto-discovery adds risk when the result writes work items to ADO. You can disable it with `disable-model-invocation: true` in the frontmatter. Doing so turns a skill into a slash command without the tool restriction or model preference support that agents and prompt files offer. Skills also can't declare tool dependencies in machine-readable frontmatter. They reference tools in body text.

--- a/_posts/2026-07-07-vibe-analytics-should-scare-you.md
+++ b/_posts/2026-07-07-vibe-analytics-should-scare-you.md
@@ -13,36 +13,36 @@ thumbnail-zoom: true
 nav-short: true
 tags: [AI, Power BI, Fabric, GitHub Copilot]
 ---
-Ask an AI tool a data question and it will usually give you an answer that sounds finished. That does not mean it chose the measure your team uses, applied the filters everyone assumes, or even queried the right source. [Vibe analytics](https://mitsloan.mit.edu/ideas-made-to-matter/working-definitions/what-is-vibe-analytics) is the habit of taking that answer at face value. The name comes from [vibe coding](https://en.wikipedia.org/wiki/Vibe_coding), Andrej Karpathy's term for letting AI write the code and accepting it without reading the diffs.
+Ask an AI tool a data question and you can get an answer that sounds finished while using the wrong measure, skipping assumed filters, or querying the wrong source. [Vibe analytics](https://mitsloan.mit.edu/ideas-made-to-matter/working-definitions/what-is-vibe-analytics) means taking that answer at face value. The name borrows from [vibe coding](https://en.wikipedia.org/wiki/Vibe_coding), Andrej Karpathy's term for letting AI write code and accepting it without reading the diffs.
 
-I built this analyst to keep the speed without hiding the work. For a focused question, it finds the governed semantic model that owns the answer. For a broader briefing, it can pull evidence together across the data landscape. Queries run under the user's identity, and every answer carries its sources, periods, and filters. Type `show dax` to see the query. The LLM is the interface. Most of the work is in the institutional knowledge that tells it what a correct answer requires.
+I built this analyst to keep the speed and expose the work. For a focused question, it finds the governed semantic model that owns the answer. For a broader briefing, it can pull evidence together across the data landscape. The analyst runs queries under the user's identity and includes its sources, periods, and filters with each answer. Type `show dax` to see the query. The LLM handles the conversation; institutional knowledge defines what a correct answer requires.
 
-This started as a side project around three months ago and turned out useful enough that people started using it across our org. It is far enough along now that I want to talk about how it works.
+I started this as a side project around three months ago. People across our org use it, and I want to explain how it works.
 
-Some context for anyone reading from outside my world: I work at Microsoft on an analytics team supporting a large ecommerce business. We aren't short on data. However, it can be a pain in the ass to find where the data lives, stitch it together across a bunch of reports and one-off spreadsheets, and then craft a story out of it.
+I work at Microsoft on an analytics team supporting a large ecommerce business. We have plenty of data. Finding where it lives, stitching it together across reports and one-off spreadsheets, and crafting a story can be a pain in the ass.
 
-The goal is not to replace reports or analysts. It is to make the governed semantic models built over our Microsoft Fabric gold layer easier to use, cut the manual stitching, capture the institutional knowledge that makes a number trustworthy, and give us more time to actually make decisions.
+The analyst complements reports and analysts. It makes the governed semantic models built over our Microsoft Fabric gold layer easier to use, cuts the manual stitching, captures the institutional knowledge that makes a number trustworthy, and gives us more time to make decisions.
 
 ## Using it
 
-Three sizes of question, one place to ask.
+I use it for three sizes of question in one place.
 
 **Small: a single metric.** "What was yesterday's value for Metric A?" It picks the right semantic model and hands you the number.
 
 **Medium: a health check.** One command gets you a cross-source briefing across a set of business areas, with each line graded against a threshold. It answers "Is anything on fire right now?" on one screen.
 
-**Large: an executive readout.** One prompt and it pulls data across every relevant model, grades each area against a performance framework, and writes an actual decision brief: what happened, why it matters, and what to do about it, ending in a ranked action list with owners.
+**Large: an executive readout.** One prompt pulls data across each relevant model, grades each area against a performance framework, and writes a decision brief: what happened, why it matters, and what to do about it, ending in a ranked action list with owners.
 
-The executive readout is where this saves the most time. Before this, putting one together meant opening a stack of reports, lining up the numbers, writing the narrative, and formatting it for leadership. The agent can do that in a couple of minutes and attach the sources. You can still inspect the query behind any answer, because "trust me" is not a feature.
+The executive readout saves me the most time. Before the agent, putting one together meant opening a stack of reports, lining up the numbers, writing the narrative, and formatting it for leadership. The agent can do that in a couple of minutes and attach the sources. I can inspect the query behind any answer and verify its filters and measures.
 
-Here is what that looks like. Ask a plain-English question and the number comes back with its receipt, the source, filters, and period it used:
+Ask a plain-English question and the answer includes its receipt: the source, filters, and period used.
 
 > **you:** what was the value of Metric A in Region A last quarter?
 >
 > **analyst:** Metric A in Region A was **X.X units**.
 > _Source: semantic model A | Filters: Region = Region A, Scenario = Actuals | Period: Previous quarter_
 
-Type `show dax` and it hands back the query it ran (real table and measure names swapped out here):
+Type `show dax` and it returns the query it ran. I replaced the real table and measure names in this example:
 
 ```dax
 EVALUATE
@@ -55,27 +55,27 @@ ROW( "Metric A",
 )
 ```
 
-## How it actually works
+## How it works
 
 The LLM handles the conversation. Routing, model guidance, and query execution are what make the answers useful.
 
-I currently support three hosts: GitHub Copilot, Microsoft 365 Copilot Cowork, and Microsoft Scout. It started as a [GitHub Copilot custom agent](https://code.visualstudio.com/docs/agent-customization/custom-agents) wired up with several [MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers). [MCP](https://modelcontextprotocol.io/docs/getting-started/intro), the Model Context Protocol, is the open standard that lets an agent talk to external tools in a consistent way.
+I support three hosts: GitHub Copilot, Microsoft 365 Copilot Cowork, and Microsoft Scout. I started with a [GitHub Copilot custom agent](https://code.visualstudio.com/docs/agent-customization/custom-agents) wired up with several [MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers). [MCP](https://modelcontextprotocol.io/docs/getting-started/intro), the Model Context Protocol, is the open standard that lets an agent talk to external tools in a consistent way.
 
 ### The MCP servers
 
-- The core is [Power BI's remote MCP server](https://learn.microsoft.com/en-us/power-bi/developer/mcp/remote-mcp-server-get-started) (in preview). It separates two steps: generating a [DAX](https://learn.microsoft.com/en-us/dax/) query from a plain-English question and executing it against a [semantic model](https://learn.microsoft.com/en-us/power-bi/connect-data/service-datasets-understand) under your identity. A one-off question gets a query generated inside the guardrails set by the model guidance: the right measures and required filters. Bigger briefings skip generation and run prewritten DAX from those files.
+- The core is [Power BI's remote MCP server](https://learn.microsoft.com/en-us/power-bi/developer/mcp/remote-mcp-server-get-started) (in preview). It separates two steps: generating a [DAX](https://learn.microsoft.com/en-us/dax/) query from a plain-English question and executing it against a [semantic model](https://learn.microsoft.com/en-us/power-bi/connect-data/service-datasets-understand) under your identity. For a one-off question, the server generates a query within guardrails supplied by the model guidance: the right measures and required filters. For bigger briefings, the agent runs prewritten DAX from those files.
 - Other tools extend the workflow:
     - The [Azure DevOps MCP Server](https://github.com/microsoft/azure-devops-mcp) files a bug when something looks broken.
     - [Web IQ](https://webiq.microsoft.ai/) fetches external market intelligence.
-    - [Work IQ](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq/) brings in work context from Microsoft 365, such as files, meetings, mail, and chats. It runs under your identity, so it only reaches content you can already access.
+    - [Work IQ](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq/) brings in work context from Microsoft 365, such as files, meetings, mail, and chats. It runs under your identity and reaches content you can access.
 
 ### The governed model
 
-The part that makes any of this trustworthy is not the LLM. It is the governed semantic model it queries. Each model encodes certified business logic, agreed definitions for core business measures, and the row-level security that decides who sees which slice. That is what separates a number you can act on from one that merely looks right.
+I rely on governed semantic models for trustworthy answers. We encode certified business logic and agreed definitions for core business measures in each model. Row-level security limits each user to the data they can access.
 
-In a medallion architecture, data lands raw (bronze), gets cleaned and conformed (silver), then is shaped into business-ready governed tables (gold). My team's semantic models are built over that Microsoft Fabric gold layer. What I built is a thin natural-language layer that queries those models in place.
+In a medallion architecture, data engineers store raw data in bronze tables, clean and conform it in silver, then shape it into business-ready gold tables. My team's semantic models use that Microsoft Fabric gold layer. I built a thin natural-language layer that queries those models in place.
 
-At a high level, a request moves through this path:
+The analyst follows this path for each request:
 
 > **Question** <span aria-hidden="true">&rarr;</span> **agent routing** <span aria-hidden="true">&rarr;</span> **registry and model guidance** <span aria-hidden="true">&rarr;</span> **governed semantic model** <span aria-hidden="true">&rarr;</span> **query result and source metadata** <span aria-hidden="true">&rarr;</span> **answer or briefing**
 
@@ -83,9 +83,9 @@ At a high level, a request moves through this path:
 
 **The agent file.** Defines routing, workflow, and every mode and command.
 
-**A model registry.** Maps each report to its exact workspace and semantic-model IDs. Once routing has picked a model, the registry resolves the target up front, so the agent does not wander around discovering what exists at runtime.
+**A model registry.** Maps each report to its exact workspace and semantic-model IDs. After the agent chooses a model, the registry resolves the target up front, so the agent does not wander around discovering what exists at runtime.
 
-**Per-model guidance.** One prompt file per report, in plain Markdown, encodes the institutional knowledge: which filters must always be present, which measures are named inconsistently across tables, which dimension value looks like a total but is not, and which measures must never feed a narrative. This is the actual product. The LLM is the flexible interface; these files carry the accumulated product knowledge.
+**Per-model guidance.** One prompt file per report, in plain Markdown, encodes the institutional knowledge: which filters must always be present, how measure names differ across tables, which dimension value looks like a total but is not, and which measures must never feed a narrative. These files carry the accumulated product knowledge; the LLM provides a flexible interface.
 
 The exact rules vary by model, but a sanitized sketch of the shape looks like this:
 
@@ -99,40 +99,40 @@ The exact rules vary by model, but a sanitized sketch of the shape looks like th
 - Never narrate from measures listed as unsafe
 ```
 
-**The execution layer.** Where the query runs: the Power BI remote MCP server in GitHub Copilot, or [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview) in the case of Cowork.
+**The execution layer.** The Power BI remote MCP server runs the query in GitHub Copilot; [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview) runs it in Cowork.
 
 ## One brain, three front doors
 
 I shipped it first as the GitHub Copilot custom agent. The first practical question was, "Great, how do I use this without opening an IDE?"
 
-So it now has three front doors:
+It has three front doors:
 
 - The [GitHub Copilot custom agent](https://code.visualstudio.com/docs/agent-customization/custom-agents) in VS Code, with the full set of MCP servers.
-- A plugin for [Microsoft 365 Copilot Cowork](https://learn.microsoft.com/en-us/microsoft-365/copilot/cowork/), where Power BI access is backed by [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview) rather than provided by a bundled MCP server.
-- A plugin for [Microsoft Scout](https://learn.microsoft.com/en-us/microsoft-scout/overview), an OpenClaw-like desktop app for Windows and macOS that acts across your files, shell, browser, and Microsoft 365. Scout supports a compatible agent-and-plugin shape built on the GitHub Copilot CLI, so the Markdown files ported cleanly; the plugin adds the MCP servers the host does not already ship.
+- A plugin for [Microsoft 365 Copilot Cowork](https://learn.microsoft.com/en-us/microsoft-365/copilot/cowork/), which uses [Fabric IQ](https://learn.microsoft.com/en-us/fabric/iq/overview) for Power BI access.
+- A plugin for [Microsoft Scout](https://learn.microsoft.com/en-us/microsoft-scout/overview), an OpenClaw-like desktop app for Windows and macOS that acts across your files, shell, browser, and Microsoft 365. Scout supports a compatible agent-and-plugin shape built on the GitHub Copilot CLI, so I ported the Markdown files with few changes; the plugin adds the MCP servers the host does not ship.
 
-The agent file and per-report prompt files form one canonical spec. A script generates the Scout desktop plugin from it by rewriting the front matter, re-anchoring file paths, and transforming the MCP configuration for that host. The Cowork edition reuses the same prompt files. These hosts are increasingly converging on the same basic shape: MCP for tools plus similar agent and skill formats. That keeps the host-specific glue small.
+The agent file and per-report prompt files form one canonical spec. A script generates the Scout desktop plugin from it by rewriting the front matter, re-anchoring file paths, and transforming the MCP configuration for that host. The Cowork edition reuses the same prompt files. These hosts are converging on the same basic shape: MCP for tools plus similar agent and skill formats. I can keep the host-specific glue small.
 
 ## Where it is going
 
-The next step is hosting it as a [Foundry hosted agent](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents). Foundry Agent Service can run a packaged agent on managed infrastructure that handles scaling and session state. A hosted version could then be published to Microsoft Teams and Microsoft 365 Copilot Chat. That would address the "meet people where they already are" problem at the platform level.
+Next, I plan to host it as a [Foundry hosted agent](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents). Foundry Agent Service can run a packaged agent on managed infrastructure that handles scaling and session state. I could publish a hosted version to Microsoft Teams and Microsoft 365 Copilot Chat, where people already work.
 
-After that, the roadmap is to add more data sources and embed the analyst more deeply into the workflows people already use every day.
+I also plan to add data sources and connect the analyst to daily workflows.
 
 ## Stuff I learned
 
-**The AI was the easy part.** Drop an LLM on your data and you get a confident, plausible, occasionally very wrong number. The hard and valuable work was writing down or referencing the institutional knowledge that makes an answer correct. That is the durable part.
+**Institutional knowledge took most of the work.** A bare LLM can return a plausible but wrong number. I spent most of the effort writing down or referencing the institutional knowledge that makes an answer correct.
 
 **"Show me the query" makes review concrete.** People do not trust a black box, and they are right not to. Letting someone inspect the filters and measures does more for trust than a claim about accuracy can.
 
-**Static checks protect the contract today.** Relevant changes run a batch of fast checks: do the golden questions still route where they should, does each model file still require the right filters, are known-bad measures still quarantined, and are the safety sections intact? The checks need no credentials or live queries and run in seconds. It is the difference between "move fast" and "move fast and start returning garbage."
+**Static checks protect the contract today.** For relevant changes, CI checks that golden questions route to the right model, model files keep their required filters, known-bad measures stay quarantined, and safety sections remain intact. The checks need no credentials or live queries and run in seconds. They catch regressions before the analyst starts returning garbage.
 
-**End-to-end trace evals are next.** The next tier will record real runs and check whether generated DAX keeps its required filters and whether every number in a narrative came from a query result rather than the model. That needs the agent running unattended, which is part of why I want it hosted on Foundry.
+**End-to-end trace evals are next.** The next tier will record real runs, check generated DAX for required filters, and trace each narrative number to a query result. I need unattended agent runs to build those evals, another reason to host it on Foundry.
 
-**Adding another supported semantic model is mostly configuration.** It needs a registry entry, per-model guidance, and routing and eval cases rather than a rebuilt application. I wrote a `CONTRIBUTING.md` with step-by-step instructions and practices that make the process repeatable.
+**Adding another supported semantic model requires configuration.** It needs a registry entry, per-model guidance, and routing and eval cases. I wrote a `CONTRIBUTING.md` with step-by-step instructions and practices that make the process repeatable.
 
 ## Wrapping up
 
-This is how I want data questions to work: ask in plain English, pull the answer from the right governed models, and keep the evidence attached. The source, filters, and query are already there when you need to review it.
+This is how I want data questions to work: ask in plain English, pull the answer from the right governed models, and keep the evidence attached. Each answer keeps its source, filters, and query attached for review.
 
 If you are building something similar, I would love to compare notes on how you encode business rules and keep the work reviewable.


### PR DESCRIPTION
## Summary
- apply the Stop Slop editing pass to the four blog posts published before July 17
- remove filler, formulaic contrasts, passive constructions, and vague phrasing while preserving grounded technical claims and personal voice
- leave all July 17 content outside this change

## Validation
- `bundle exec jekyll build --config _config.yml,_config-dev.yml`
- `git diff --check`
- quick checks found no em dashes, banned filler phrases, formulaic contrasts, or Wh-word prose openings