### PR TITLE
Label the homepage featured lead and stop letterboxing its image

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -33,19 +33,23 @@ layout: base
   2-col (641-1024px) breakpoints — hence limit:13, not 12.{% endcomment %}
   {% for post in site.posts limit: 13 %}
     {% if forloop.first %}
-    {% comment %}Featured (newest) post — full-width lead, Fraunces title{% endcomment %}
-    <article class="post-card modern-card post-card--featured fade-in-up" style="--delay:240;">
-      <a href="{{ post.url | relative_url }}" class="post-card-link" aria-label="Read: {{ post.title | escape }}">
+    {% comment %}Featured (newest) post — labelled full-width lead, Fraunces title.
+    Without a thumbnail the card gets .post-card--featured-text so the copy uses the
+    full measure instead of leaving the 40% image column empty.{% endcomment %}
+    <article class="post-card modern-card post-card--featured{% unless post.thumbnail-img or post.cover-img %} post-card--featured-text{% endunless %} fade-in-up" style="--delay:240;">
+      <a href="{{ post.url | relative_url }}" class="post-card-link" aria-label="Latest post: {{ post.title | escape }}">
         {% if post.thumbnail-img or post.cover-img %}
+        {% comment %}Above the fold, so this is the LCP element — never lazy-loaded.{% endcomment %}
         <div class="post-card-image-container" aria-hidden="true">
           {% if post.thumbnail-img %}
-            <img src="{{ post.thumbnail-img | relative_url }}" alt="" class="post-card-image" loading="lazy" />
+            <img src="{{ post.thumbnail-img | relative_url }}" alt="" class="post-card-image" loading="eager" fetchpriority="high" decoding="async" />
           {% else %}
-            <img src="{{ post.cover-img | relative_url }}" alt="" class="post-card-image" loading="lazy" />
+            <img src="{{ post.cover-img | relative_url }}" alt="" class="post-card-image" loading="eager" fetchpriority="high" decoding="async" />
           {% endif %}
         </div>
         {% endif %}
         <div class="post-card-content">
+          <p class="post-card-eyebrow">Latest post</p>
           <h2 class="post-card-title">{{ post.title }}</h2>
           {% if post.excerpt %}
             <div class="post-card-excerpt">{{ post.excerpt | strip_html | truncatewords: 32 }}</div>
@@ -58,6 +62,8 @@ layout: base
             <span aria-hidden="true">·</span>
             <span class="reading-time">{{ minutes }} min read</span>
           </div>
+          {% comment %}A span, not a link — the whole card is already one anchor.{% endcomment %}
+          <span class="post-card-cta">Read the post <i class="fas fa-arrow-right" aria-hidden="true"></i></span>
         </div>
       </a>
     </article>

--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -3277,7 +3277,7 @@ body.modern {
 .post-card.modern-card .post-card-excerpt { font-size:.9rem; line-height:1.56; color:var(--text-secondary); margin-top:.6rem; flex-grow:1; }
 .post-card.modern-card .post-card-meta { font-size: var(--type-meta); letter-spacing:.02em; color:var(--text-muted); margin-top:.95rem; display:flex; align-items:center; gap:.4rem; }
 
-/* ===== FEATURED (newest) post — full-width lead, Fraunces title (Fenster §2.3) =====
+/* ===== FEATURED (newest) post — labelled full-width lead (Fenster §2.3) =====
  * Selectors carry .post-card.modern-card too, so they outrank the base card
  * rules (which are .post-card.modern-card ...) rather than losing to them. */
 .post-card.modern-card.post-card--featured {
@@ -3291,14 +3291,72 @@ body.modern {
 }
 .post-card.modern-card.post-card--featured:hover,
 .post-card.modern-card.post-card--featured:focus-within { transform: none; border-color: var(--border); box-shadow: none; }
-.post-card.modern-card.post-card--featured .post-card-link { flex-direction: row-reverse; align-items: stretch; gap: clamp(1.25rem, 3vw, 2.5rem); }
-.post-card.modern-card.post-card--featured .post-card-image-container { flex: 0 0 40%; border: 0; border-radius: var(--radius-md); min-height: 220px; }
+.post-card.modern-card.post-card--featured .post-card-link { flex-direction: row-reverse; align-items: center; gap: clamp(1.5rem, 3.5vw, 3rem); }
+/* The image fills its column. Without these overrides the index-card rules
+ * (max-height:200px, width/height:auto) cap the lead — a 1440x800 asset landed
+ * at 360x200 inside a 500px column, leaving ~70px of dead gutter either side. */
+.post-card.modern-card.post-card--featured .post-card-image-container {
+  flex: 0 0 40%;
+  border: 0;
+  border-radius: var(--radius-md);
+  /* height:auto is load-bearing — the legacy §7 `.post-card-image-container
+   * { height: 180px }` otherwise wins (nothing else sets `height`) and
+   * aspect-ratio never gets to size the box. */
+  height: auto;
+  aspect-ratio: 16 / 9;
+  min-height: 0;
+}
+.post-card.modern-card.post-card--featured .post-card-image {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: none;
+  object-fit: contain;
+}
 .post-card.modern-card.post-card--featured .post-card-content { flex: 1 1 60%; padding: 0; justify-content: center; }
-.post-card.modern-card.post-card--featured .post-card-title { font-family: var(--font-display); font-size: var(--type-featured); font-weight: 540; line-height: 1.1; letter-spacing: -0.01em; }
-.post-card.modern-card.post-card--featured .post-card-excerpt { font-size: var(--type-body); line-height: var(--lh-body); max-width: 60ch; margin-top: .85rem; }
+/* The eyebrow is what tells a reader this is the newest post rather than a
+ * second hero headline; the orange rule is the site's one heading marker. */
+.post-card.modern-card.post-card--featured .post-card-eyebrow {
+  font-size: var(--type-eyebrow);
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 0.7rem;
+}
+.post-card.modern-card.post-card--featured .post-card-eyebrow::before {
+  content: "";
+  display: block;
+  width: 2.5rem;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  margin-bottom: 0.75rem;
+}
+.post-card.modern-card.post-card--featured .post-card-title { font-family: var(--font-display); font-size: var(--type-featured); font-weight: 540; line-height: 1.1; letter-spacing: -0.01em; margin-top: 0; }
+/* flex-grow:0 undoes the index-card rule that otherwise strands the meta line
+ * at the bottom of the column, away from the copy it belongs to. */
+.post-card.modern-card.post-card--featured .post-card-excerpt { font-size: var(--type-body); line-height: var(--lh-body); max-width: 60ch; margin-top: .85rem; flex-grow: 0; }
 .post-card.modern-card.post-card--featured .post-card-meta { margin-top: 1rem; }
+.post-card.modern-card.post-card--featured .post-card-cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: .5ch;
+  margin-top: 1.1rem;
+  color: var(--accent);
+  font-size: .9rem;
+  font-weight: 600;
+  letter-spacing: .01em;
+}
+.post-card.modern-card.post-card--featured .post-card-cta i { font-size: .7em; transition: transform .2s var(--ease-out); }
+.post-card.modern-card.post-card--featured:hover .post-card-cta i,
+.post-card.modern-card.post-card--featured:focus-within .post-card-cta i { transform: translateX(3px); }
 .post-card.modern-card.post-card--featured:hover .post-card-title,
 .post-card.modern-card.post-card--featured:focus-within .post-card-title { color: var(--accent); }
+/* No thumbnail: use the full measure instead of leaving the image column empty. */
+.post-card.modern-card.post-card--featured-text .post-card-link { display: block; }
+.post-card.modern-card.post-card--featured-text .post-card-excerpt { max-width: var(--measure); }
 /* Browse full archive — a single quiet ghost text link (Fenster §2.5) */
 .browse-archive-btn { text-align:center; margin: clamp(2rem, 4vw, 3rem) 0 1.6rem; }
 .browse-archive-btn a { display:inline-flex; align-items:center; gap:.5ch; min-height:44px; padding:.5rem .35rem; color: var(--accent); font-size:.9rem; font-weight:600; letter-spacing:.01em; text-decoration:none; transition: color var(--transition); }
@@ -3339,7 +3397,7 @@ a:focus-visible { outline:2px solid var(--focus-ring); outline-offset:2px; }
 }
 @media (max-width: 640px) {
   .post-card.modern-card.post-card--featured .post-card-link { flex-direction: column; gap: 1rem; }
-  .post-card.modern-card.post-card--featured .post-card-image-container { flex: 0 0 auto; width: 100%; min-height: 180px; }
+  .post-card.modern-card.post-card--featured .post-card-image-container { flex: 0 0 auto; width: 100%; }
   .post-card.modern-card.post-card--featured .post-card-content { padding: 0; }
 }
 @media (max-width: 520px) {

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -68,6 +68,48 @@ test('should render the newest post as the full-width featured lead card', async
   await expect(page.locator('.post-card--featured')).toHaveCount(1);
 });
 
+test('the featured lead is labelled and offers a read affordance', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto('');
+
+  const featured = page.locator('.post-card--featured');
+
+  // Without the eyebrow the Fraunces title reads as a second hero headline
+  // (uppercased via CSS, so assert the source text case-insensitively)
+  await expect(featured.locator('.post-card-eyebrow')).toHaveText(/^latest post$/i);
+  await expect(featured.locator('.post-card-cta')).toBeVisible();
+
+  // The CTA is a span, not a nested link — the whole card is already one anchor
+  await expect(featured.locator('a')).toHaveCount(1);
+});
+
+test('the featured lead image fills its column instead of letterboxing', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto('', { waitUntil: 'load' });
+
+  const container = page.locator('.post-card--featured .post-card-image-container');
+  if ((await container.count()) === 0) return; // newest post has no thumbnail
+
+  const img = page.locator('.post-card--featured .post-card-image');
+  await expect(async () => {
+    const w = await img.evaluate((el: HTMLImageElement) => el.naturalWidth);
+    expect(w).toBeGreaterThan(0);
+  }).toPass({ timeout: 5000 });
+
+  const box = await container.boundingBox();
+  const imgBox = await img.boundingBox();
+  expect(box).not.toBeNull();
+  expect(imgBox).not.toBeNull();
+
+  // object-fit:contain matches one axis exactly; the index-card max-height:200px
+  // and the legacy height:180px must not cap the lead (that left ~70px of dead
+  // gutter either side of a 1440x800 asset).
+  const fillsWidth = imgBox!.width >= box!.width * 0.97;
+  const fillsHeight = imgBox!.height >= box!.height * 0.97;
+  expect(fillsWidth || fillsHeight).toBe(true);
+  expect(imgBox!.height).toBeGreaterThan(200);
+});
+
 test('should render a plain Popular list of links (no counters, no emoji)', async ({ page }) => {
   await page.goto('');
 


### PR DESCRIPTION
## Why

The newest post sat directly under the hero as an unlabelled full-width lead. Because the featured card is the third Fraunces slot (Fenster §2.3), the page opened with a 68px Fraunces `h1` followed immediately by a 42.5px Fraunces `h2` with no eyebrow, divider, or card edge between them. It read as a second hero headline rather than "here is the latest post."

Two structural bugs made it worse:

**The image was letterboxed.** The featured card never overrode the index-card image rules, so `max-height: 200px`, `width/height: auto` and `object-fit: contain` all applied. A 1440x800 asset rendered at 360x200 inside a 500x220 container, leaving roughly 70px of dead gutter on each side. The real culprit was a legacy `.post-card-image-container { height: 180px }` further up the sheet: nothing in the featured block set `height`, so that bare class selector won, and an explicit `height` defeats `aspect-ratio` outright.

**The meta line was stranded.** `justify-content: center` combined with the inherited `.post-card-excerpt { flex-grow: 1 }` pushed the date and reading time 35px below the excerpt and past the image box's bottom edge, so the two columns did not line up.

The layout shape also depended on front matter. The image column is wrapped in `{% if post.thumbnail-img or post.cover-img %}` with no fallback, so a newest post without a thumbnail left 40% of the row empty. That is not hypothetical: it was the live state of the homepage at one point during this work.

## What changed

- **Eyebrow.** A `Latest post` label above the title, using the site's single heading treatment (solid orange rule, 2.5rem x 2px) and the existing eyebrow type scale. This is what tells a reader the lead is the newest post.
- **Image fills its column.** `height: auto` plus `aspect-ratio: 16 / 9` on the featured container, and `max-height: none` on the image. It now measures 500x281 at 1440px instead of 360x200. The `height: auto` is load-bearing and carries a comment saying so.
- **Columns align.** `flex-grow: 0` on the featured excerpt, so the meta line sits with the copy it belongs to. Both columns now bottom-align.
- **Read affordance.** A `Read the post ->` CTA with a 3px arrow nudge on hover and focus. It is a `<span>`, not a nested anchor, since the whole card is already one link. This is not a revival of the removed `.read-more-chip`: it appears on the single lead, not on all 12 index cards.
- **Graceful without a thumbnail.** A `post-card--featured-text` modifier switches the link to `display: block` and widens the excerpt to `var(--measure)`, so the row is never half empty and no grey placeholder box appears.
- **LCP.** The lead image is above the fold, so it is now `loading="eager" fetchpriority="high" decoding="async"` instead of lazy.
- **A11y.** The link's `aria-label` is now `Latest post: <title>`, since the eyebrow lives inside the labelled anchor and would otherwise not be announced.

Deliberately untouched: `limit: 13`, the row-math comment, and the index-card branch. The featured selectors carry `.post-card.modern-card` so they out-specify the base rules on specificity rather than relying on source order.

## Testing

Two tests added to `tests/landing.spec.ts`, next to the existing featured-lead spec:

- The lead is labelled and offers a read affordance, and still contains exactly one anchor.
- The lead image fills its column. Asserts `naturalWidth > 0` first, then that the rendered box matches the container on at least one axis and clears 200px in height, which is the specific regression that `max-height: 200px` and `height: 180px` caused.

Full suite: 76 passed. Checked manually at 1440px, 390px and 320px with no horizontal overflow, plus the no-thumbnail path.